### PR TITLE
Fix parameter passing and random crop

### DIFF
--- a/morphocell/image_utils.py
+++ b/morphocell/image_utils.py
@@ -282,10 +282,11 @@ def random_crop(
     x1, y1, x2, y2 = get_random_crop_coords(
         height, width, crop_h, crop_w, h_start, w_start
     )
+    cropped = img[:, y1:y2, x1:x2] if img.ndim > 2 else img[y1:y2, x1:x2]
     if return_coordinates:
-        return (img[y1:y2, x1:x2], (y1, y2, x1, x2))
+        return (cropped, (y1, y2, x1, x2))
     else:
-        return img[y1:y2, x1:x2]
+        return cropped
 
 
 def crop_to_divisor(

--- a/morphocell/segmentation/cellpose.py
+++ b/morphocell/segmentation/cellpose.py
@@ -29,8 +29,13 @@ def cellpose_eval(
     do_3D: bool = True,
 ) -> npt.ArrayLike:
     """Run pre-trained Cellpose model and return masks."""
-    model = models.Cellpose(gpu=True, model_type="cyto", omni=False)
-    masks, _, _, _ = model.eval(image, channels=channels, diameter=diameter, do_3D=True)
+    model = models.Cellpose(gpu=True, model_type=model_type, omni=omni)
+    masks, _, _, _ = model.eval(
+        image,
+        channels=channels,
+        diameter=diameter,
+        do_3D=do_3D,
+    )
     return masks
 
 


### PR DESCRIPTION
## Summary by Sourcery

Allow passing of custom model parameters to Cellpose evaluation and improve random_crop slicing logic

Bug Fixes:
- Use the provided model_type, omni, and do_3D arguments when instantiating and evaluating the Cellpose model
- Correct random_crop to accurately handle multi-channel images and return a single cropped array

Enhancements:
- Introduce a unified cropped variable in random_crop to avoid redundant slicing operations