### PR TITLE
Make trimesh optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
 dependencies = [
     "numpy>=1.20.0",
     "scikit-image>=0.16.1",
-    "trimesh>=3.3.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -54,9 +53,13 @@ flowdec = [
     "cloudpickle>=2.0",
     "py3nvml>=0.2.6",
 ]
+mesh = [
+    "trimesh>=3.3.0",
+]
 all = [
     "morphocell[cellpose]",
     "morphocell[dev]",
+    "morphocell[mesh]",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Summary
- add optional mesh extra with trimesh
- gracefully warn when trimesh isn't installed
- check for trimesh before executing mesh feature functions

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy --ignore-missing-imports morphocell/` *(fails: Found 85 errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865a7e2cab88330a1b71a4ff49bb2e9