### PR TITLE
Add optional trimesh support

### DIFF
--- a/morphocell/feature/mesh.py
+++ b/morphocell/feature/mesh.py
@@ -9,21 +9,21 @@ from functools import wraps
 import numpy as np
 from skimage.measure import marching_cubes
 
+_TRIMESH_AVAILABLE = False
 try:  # pragma: no cover - optional dependency
     import trimesh
     from trimesh.curvature import (
         discrete_mean_curvature_measure,
         discrete_gaussian_curvature_measure,
     )
-
-    _TRIMESH_AVAILABLE = True
-except Exception:  # pragma: no cover - import failure path
+except ImportError:  # pragma: no cover - import failure path
     trimesh = None
-    _TRIMESH_AVAILABLE = False
     warnings.warn(
         "trimesh is not installed. Mesh features are unavailable.",
         stacklevel=2,
     )
+else:
+    _TRIMESH_AVAILABLE = True
 
 from ..cuda import asnumpy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
 dependencies = [
     "numpy>=1.20.0",
     "scikit-image>=0.16.1",
-    "trimesh>=3.3.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -40,6 +39,9 @@ Repository = "https://github.com/alxndrkalinin/morphocell"
 cellpose = [
     "cellpose>=2.0,<4.0",
 ]
+mesh = [
+    "trimesh>=3.3.0",
+]
 dev = [
     "ruff",
     "mypy",
@@ -49,6 +51,7 @@ dev = [
 ]
 all = [
     "morphocell[cellpose]",
+    "morphocell[mesh]",
     "morphocell[dev]",
 ]
 


### PR DESCRIPTION
## Summary
- add new 'mesh' optional dependency group with trimesh
- handle absent trimesh in `morphocell.feature.mesh`
- reuse decorator to validate trimesh availability

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy --ignore-missing-imports morphocell/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686756fa6534833091da8a55b4df07fb

## Summary by Sourcery

Enable optional trimesh support by making it an extra dependency and enforcing runtime checks

Enhancements:
- Make trimesh an optional dependency and define mesh extra in pyproject.toml
- Guard trimesh imports with try/except and warn if it’s unavailable
- Add `_require_trimesh` decorator to enforce trimesh availability in mesh functions
- Apply availability checks to mesh feature extraction functions