### PR TITLE
feat(metrics): expose alpha_min + alpha_max kwargs in microssim

### DIFF
--- a/cubic/__init__.py
+++ b/cubic/__init__.py
@@ -1,3 +1,3 @@
 """Morphomeric analysis of 3D cell images."""
 
-__version__ = "0.7.0a6"
+__version__ = "0.7.0a7"

--- a/cubic/metrics/microssim/__init__.py
+++ b/cubic/metrics/microssim/__init__.py
@@ -5,7 +5,12 @@ Device-agnostic (NumPy / CuPy) implementation. Public API is exposed via
 from this subpackage.
 """
 
-from .ri_factor import ALPHA_MAX_DEFAULT, get_ri_factor, get_global_ri_factor
+from .ri_factor import (
+    ALPHA_MAX_DEFAULT,
+    ALPHA_MIN_DEFAULT,
+    get_ri_factor,
+    get_global_ri_factor,
+)
 from .micro_ssim import MicroSSIM, micro_structural_similarity
 from .micro_ms3im import MicroMS3IM, micro_multiscale_structural_similarity
 from .ssim_elements import SSIMElements, compute_ssim_elements
@@ -17,6 +22,7 @@ from .image_processing import (
 
 __all__ = [
     "ALPHA_MAX_DEFAULT",
+    "ALPHA_MIN_DEFAULT",
     "MicroMS3IM",
     "MicroSSIM",
     "SSIMElements",

--- a/cubic/metrics/microssim/__init__.py
+++ b/cubic/metrics/microssim/__init__.py
@@ -5,7 +5,7 @@ Device-agnostic (NumPy / CuPy) implementation. Public API is exposed via
 from this subpackage.
 """
 
-from .ri_factor import get_ri_factor, get_global_ri_factor
+from .ri_factor import ALPHA_MAX_DEFAULT, get_ri_factor, get_global_ri_factor
 from .micro_ssim import MicroSSIM, micro_structural_similarity
 from .micro_ms3im import MicroMS3IM, micro_multiscale_structural_similarity
 from .ssim_elements import SSIMElements, compute_ssim_elements
@@ -16,6 +16,7 @@ from .image_processing import (
 )
 
 __all__ = [
+    "ALPHA_MAX_DEFAULT",
     "MicroMS3IM",
     "MicroSSIM",
     "SSIMElements",

--- a/cubic/metrics/microssim/micro_ssim.py
+++ b/cubic/metrics/microssim/micro_ssim.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 
 import numpy as np
 
-from .ri_factor import get_global_ri_factor
+from .ri_factor import ALPHA_MAX_DEFAULT, get_global_ri_factor
 from .ssim_elements import compute_ssim_elements
 from .image_processing import (
     normalize_min_max,
@@ -42,6 +42,12 @@ class MicroSSIM:
         Pre-computed RI factor. If supplied, all of ``offset_gt``,
         ``offset_pred``, and ``max_val`` must also be supplied; in that
         case ``score()`` can be called without first calling ``fit()``.
+        Use this to pin ``alpha`` from an external calibration (e.g.
+        load a per-(model, organelle) RI factor fit once and reuse it
+        across all evaluation calls).
+    alpha_max : float, default=:data:`ALPHA_MAX_DEFAULT` (``1e6``)
+        Upper bracket cap forwarded to :func:`get_global_ri_factor` during
+        ``fit()``. Has no effect when ``ri_factor`` is supplied directly.
 
     Raises
     ------
@@ -57,12 +63,14 @@ class MicroSSIM:
         offset_pred: float | None = None,
         max_val: float | None = None,
         ri_factor: float | None = None,
+        alpha_max: float = ALPHA_MAX_DEFAULT,
     ) -> None:
         self._bg_percentile = bg_percentile
         self._offset_pred = offset_pred
         self._offset_gt = offset_gt
         self._max_val = max_val
         self._ri_factor = ri_factor
+        self._alpha_max = alpha_max
         self._initialized = ri_factor is not None
         if self._initialized and any(
             p is None for p in (offset_gt, offset_pred, max_val)
@@ -149,7 +157,9 @@ class MicroSSIM:
         # (ri_factor.py:123-131). gaussian_weights=False, win_size=7,
         # crop=True is the fit-time path — these are the defaults of
         # get_global_ri_factor (matches upstream ri_factor.py:89).
-        self._ri_factor = get_global_ri_factor(gt_norm, pred_norm)
+        self._ri_factor = get_global_ri_factor(
+            gt_norm, pred_norm, alpha_max=self._alpha_max
+        )
         self._initialized = True
         return self
 

--- a/cubic/metrics/microssim/micro_ssim.py
+++ b/cubic/metrics/microssim/micro_ssim.py
@@ -65,6 +65,8 @@ class MicroSSIM:
         ri_factor: float | None = None,
         alpha_max: float = ALPHA_MAX_DEFAULT,
     ) -> None:
+        if not (np.isfinite(alpha_max) and alpha_max > 1.0):
+            raise ValueError(f"alpha_max must be a finite float > 1; got {alpha_max}")
         self._bg_percentile = bg_percentile
         self._offset_pred = offset_pred
         self._offset_gt = offset_gt

--- a/cubic/metrics/microssim/micro_ssim.py
+++ b/cubic/metrics/microssim/micro_ssim.py
@@ -12,7 +12,12 @@ from typing import Any, cast
 
 import numpy as np
 
-from .ri_factor import ALPHA_MAX_DEFAULT, get_global_ri_factor
+from .ri_factor import (
+    ALPHA_MAX_DEFAULT,
+    ALPHA_MIN_DEFAULT,
+    get_global_ri_factor,
+    _validate_alpha_bounds,
+)
 from .ssim_elements import compute_ssim_elements
 from .image_processing import (
     normalize_min_max,
@@ -45,6 +50,9 @@ class MicroSSIM:
         Use this to pin ``alpha`` from an external calibration (e.g.
         load a per-(model, organelle) RI factor fit once and reuse it
         across all evaluation calls).
+    alpha_min : float, default=:data:`ALPHA_MIN_DEFAULT` (``1e-6``)
+        Lower bracket cap forwarded to :func:`get_global_ri_factor` during
+        ``fit()``. Has no effect when ``ri_factor`` is supplied directly.
     alpha_max : float, default=:data:`ALPHA_MAX_DEFAULT` (``1e6``)
         Upper bracket cap forwarded to :func:`get_global_ri_factor` during
         ``fit()``. Has no effect when ``ri_factor`` is supplied directly.
@@ -53,7 +61,8 @@ class MicroSSIM:
     ------
     ValueError
         If ``ri_factor`` is provided but any of the normalization
-        parameters is missing (matches upstream ``micro_ssim.py:270-279``).
+        parameters is missing (matches upstream ``micro_ssim.py:270-279``),
+        or if ``alpha_min`` / ``alpha_max`` are out of range.
     """
 
     def __init__(
@@ -64,15 +73,16 @@ class MicroSSIM:
         max_val: float | None = None,
         ri_factor: float | None = None,
         *,
+        alpha_min: float = ALPHA_MIN_DEFAULT,
         alpha_max: float = ALPHA_MAX_DEFAULT,
     ) -> None:
-        if not (np.isfinite(alpha_max) and alpha_max > 1.0):
-            raise ValueError(f"alpha_max must be a finite float > 1; got {alpha_max}")
+        _validate_alpha_bounds(alpha_min, alpha_max)
         self._bg_percentile = bg_percentile
         self._offset_pred = offset_pred
         self._offset_gt = offset_gt
         self._max_val = max_val
         self._ri_factor = ri_factor
+        self._alpha_min = alpha_min
         self._alpha_max = alpha_max
         self._initialized = ri_factor is not None
         if self._initialized and any(
@@ -161,7 +171,10 @@ class MicroSSIM:
         # crop=True is the fit-time path — these are the defaults of
         # get_global_ri_factor (matches upstream ri_factor.py:89).
         self._ri_factor = get_global_ri_factor(
-            gt_norm, pred_norm, alpha_max=self._alpha_max
+            gt_norm,
+            pred_norm,
+            alpha_min=self._alpha_min,
+            alpha_max=self._alpha_max,
         )
         self._initialized = True
         return self
@@ -242,10 +255,11 @@ class MicroSSIM:
         Notes
         -----
         The key set intentionally mirrors upstream ``MicroSSIM``. The
-        cubic-only ``alpha_max`` knob is **not** round-tripped here — a
-        ``MicroSSIM(**ms.get_parameters())`` re-instantiation reverts
-        ``alpha_max`` to :data:`ALPHA_MAX_DEFAULT`. Save it separately if
-        a non-default cap is part of your configuration.
+        cubic-only ``alpha_min`` / ``alpha_max`` knobs are **not**
+        round-tripped here — a ``MicroSSIM(**ms.get_parameters())``
+        re-instantiation reverts them to :data:`ALPHA_MIN_DEFAULT` /
+        :data:`ALPHA_MAX_DEFAULT`. Save them separately if non-default
+        caps are part of your configuration.
         """
         return {
             "bg_percentile": self._bg_percentile,

--- a/cubic/metrics/microssim/micro_ssim.py
+++ b/cubic/metrics/microssim/micro_ssim.py
@@ -63,6 +63,7 @@ class MicroSSIM:
         offset_pred: float | None = None,
         max_val: float | None = None,
         ri_factor: float | None = None,
+        *,
         alpha_max: float = ALPHA_MAX_DEFAULT,
     ) -> None:
         if not (np.isfinite(alpha_max) and alpha_max > 1.0):
@@ -237,6 +238,14 @@ class MicroSSIM:
             Keys ``bg_percentile``, ``offset_pred``, ``offset_gt``,
             ``max_val``, ``ri_factor`` matching upstream
             ``micro_ssim.py:296-302`` exactly.
+
+        Notes
+        -----
+        The key set intentionally mirrors upstream ``MicroSSIM``. The
+        cubic-only ``alpha_max`` knob is **not** round-tripped here — a
+        ``MicroSSIM(**ms.get_parameters())`` re-instantiation reverts
+        ``alpha_max`` to :data:`ALPHA_MAX_DEFAULT`. Save it separately if
+        a non-default cap is part of your configuration.
         """
         return {
             "bg_percentile": self._bg_percentile,

--- a/cubic/metrics/microssim/ri_factor.py
+++ b/cubic/metrics/microssim/ri_factor.py
@@ -214,7 +214,7 @@ def _bracket_root(
 
 
 def get_ri_factor(
-    elements: SSIMElements, alpha_max: float = ALPHA_MAX_DEFAULT
+    elements: SSIMElements, *, alpha_max: float = ALPHA_MAX_DEFAULT
 ) -> float:
     """Compute the range-invariant factor by bisection on ``dS/dalpha = 0``.
 
@@ -237,6 +237,10 @@ def get_ri_factor(
         covers most reasonable MicroSSIM fits where the optimum sits near
         ``alpha = 1``; raise it for pathological inputs (very small
         calibration sets, heavily mis-normalized predictions).
+
+        Note: bracket probes are powers of 2 starting at 2. The largest
+        probed value is therefore the largest power of 2 not exceeding
+        ``alpha_max`` (e.g., ``2**19 = 524288`` for ``alpha_max = 1e6``).
 
     Returns
     -------
@@ -300,6 +304,7 @@ def get_ri_factor(
 def get_global_ri_factor(
     gt: np.ndarray,
     pred: np.ndarray,
+    *,
     alpha_max: float = ALPHA_MAX_DEFAULT,
     **ssim_kwargs: object,
 ) -> float:
@@ -337,9 +342,14 @@ def get_global_ri_factor(
     Raises
     ------
     ValueError
-        If ``gt`` and ``pred`` differ in shape, or either has ``ndim`` not
-        in ``{2, 3}``.
+        If ``alpha_max <= 1`` (see :func:`get_ri_factor`), ``gt`` and
+        ``pred`` differ in shape, or either has ``ndim`` not in
+        ``{2, 3}``.
     """
+    # Validate alpha_max up-front so a bad value fails before the
+    # potentially-expensive per-slice compute_ssim_elements loop.
+    if not (np.isfinite(alpha_max) and alpha_max > 1.0):
+        raise ValueError(f"alpha_max must be a finite float > 1; got {alpha_max}")
     if gt.shape != pred.shape:
         raise ValueError(
             f"Ground-truth and prediction arrays must have the same shape "

--- a/cubic/metrics/microssim/ri_factor.py
+++ b/cubic/metrics/microssim/ri_factor.py
@@ -25,8 +25,9 @@ Analytical derivative (per-pixel):
 
 ``f(alpha)`` is the mean of ``dS_n/dalpha`` over all flattened element pixels.
 MicroSSIM normalization places the optimum near ``alpha = 1``; we bracket by
-doubling outwards from ``alpha = 1`` (cap ``1e-3 <= alpha <= 1e3``) and refine
-with bisection terminated on both ``|f(mid)| < 1e-10`` AND ``|hi - lo| < 1e-8``.
+doubling outwards from ``alpha = 1`` (default cap ``1e-3 <= alpha <= 1e6``;
+the upper bound is configurable via the ``alpha_max`` kwarg) and refine with
+bisection terminated on both ``|f(mid)| < 1e-10`` AND ``|hi - lo| < 1e-8``.
 """
 
 from __future__ import annotations
@@ -40,7 +41,7 @@ from .ssim_elements import SSIMElements, compute_ssim_elements
 # conjunctive termination guards both flat-region stalls (pure |f| tol)
 # and tiny-slope spinning (pure x tol).
 _ALPHA_INIT = 1.0
-_ALPHA_MAX = 1e3
+ALPHA_MAX_DEFAULT = 1e6
 _ALPHA_MIN = 1e-3
 _F_TOL = 1e-10
 _X_TOL = 1e-8
@@ -152,7 +153,7 @@ def _flatten_elements(elements: SSIMElements) -> SSIMElements:
 
 
 def _bracket_root(
-    elements: SSIMElements, f1: float
+    elements: SSIMElements, f1: float, alpha_max: float
 ) -> tuple[float, float, float, float]:
     """Find ``(lo, hi)`` with opposite-sign ``f`` values by expanding from 1.
 
@@ -167,6 +168,9 @@ def _bracket_root(
         Flattened SSIM elements (variances / covariance).
     f1 : float
         Value of ``f(1)``; sign decides direction.
+    alpha_max : float
+        Upper bracket cap. Doubling expansion stops once ``alpha`` exceeds
+        this value without a sign change.
 
     Returns
     -------
@@ -177,13 +181,13 @@ def _bracket_root(
     Raises
     ------
     RuntimeError
-        If no sign change is found within ``[_ALPHA_MIN, _ALPHA_MAX]``.
+        If no sign change is found within ``[_ALPHA_MIN, alpha_max]``.
     """
     if f1 > 0.0:
         # f(1) > 0: root is to the right of 1 — expand by doubling.
         lo, f_lo = _ALPHA_INIT, f1
         alpha = _ALPHA_INIT * 2.0
-        while alpha <= _ALPHA_MAX:
+        while alpha <= alpha_max:
             f_alpha = _compute_dS_mean(alpha, elements)
             if f_alpha == 0.0 or (f_alpha < 0.0):
                 return lo, alpha, f_lo, f_alpha
@@ -191,7 +195,8 @@ def _bracket_root(
             alpha *= 2.0
         raise RuntimeError(
             "RI factor failed to bracket on the right; input may violate "
-            f"fit assumptions. ux shape={elements.ux.shape}"
+            f"fit assumptions or alpha_max={alpha_max} is too small. "
+            f"ux shape={elements.ux.shape}"
         )
     # f(1) < 0: root is to the left of 1 — expand by halving.
     hi, f_hi = _ALPHA_INIT, f1
@@ -208,7 +213,9 @@ def _bracket_root(
     )
 
 
-def get_ri_factor(elements: SSIMElements) -> float:
+def get_ri_factor(
+    elements: SSIMElements, alpha_max: float = ALPHA_MAX_DEFAULT
+) -> float:
     """Compute the range-invariant factor by bisection on ``dS/dalpha = 0``.
 
     The MicroSSIM range-invariant factor ``alpha`` is the scalar multiplier
@@ -225,6 +232,11 @@ def get_ri_factor(elements: SSIMElements) -> float:
         taken over all pixels. ``C1`` and ``C2`` are taken from the
         ``elements`` object (callers using :func:`get_global_ri_factor` get
         the last-slice values, matching upstream).
+    alpha_max : float, default=:data:`ALPHA_MAX_DEFAULT` (``1e6``)
+        Upper bracket cap for the doubling expansion. The default safely
+        covers most reasonable MicroSSIM fits where the optimum sits near
+        ``alpha = 1``; raise it for pathological inputs (very small
+        calibration sets, heavily mis-normalized predictions).
 
     Returns
     -------
@@ -235,8 +247,11 @@ def get_ri_factor(elements: SSIMElements) -> float:
     ------
     RuntimeError
         If the bracketing phase fails to find a sign change within
-        ``[1e-3, 1e3]`` — typical for pathological inputs (constant ground
-        truth with non-constant prediction, or all-zero prediction).
+        ``[1e-3, alpha_max]`` — typical for pathological inputs (constant
+        ground truth with non-constant prediction, or all-zero prediction).
+    ValueError
+        If ``alpha_max <= 1`` (the bracket starts at ``alpha = 1`` and
+        expands rightward, so any cap at or below 1 is degenerate).
 
     Notes
     -----
@@ -245,13 +260,15 @@ def get_ri_factor(elements: SSIMElements) -> float:
     invariant ``mean(S(alpha*)) >= mean(S(1)) - 1e-12`` is asserted (with
     slack to allow ``alpha = 1`` itself being the optimum).
     """
+    if not (np.isfinite(alpha_max) and alpha_max > 1.0):
+        raise ValueError(f"alpha_max must be a finite float > 1; got {alpha_max}")
     flat = _flatten_elements(elements)
 
     f1 = _compute_dS_mean(_ALPHA_INIT, flat)
     if abs(f1) < _INIT_F_TOL:
         return float(_ALPHA_INIT)
 
-    lo, hi, f_lo, f_hi = _bracket_root(flat, f1)
+    lo, hi, f_lo, f_hi = _bracket_root(flat, f1, alpha_max)
 
     # Bisection refinement. The conjunction of |f| and x tolerances guards
     # both stalling in flat regions and spinning on near-zero slope.
@@ -281,7 +298,10 @@ def get_ri_factor(elements: SSIMElements) -> float:
 
 
 def get_global_ri_factor(
-    gt: np.ndarray, pred: np.ndarray, **ssim_kwargs: object
+    gt: np.ndarray,
+    pred: np.ndarray,
+    alpha_max: float = ALPHA_MAX_DEFAULT,
+    **ssim_kwargs: object,
 ) -> float:
     """Compute the range-invariant factor on a stack of images.
 
@@ -300,6 +320,8 @@ def get_global_ri_factor(
         here; pool such inputs at the ``MicroSSIM.fit`` layer.
     pred : numpy.ndarray
         Prediction stack; same shape as ``gt``.
+    alpha_max : float, default=:data:`ALPHA_MAX_DEFAULT` (``1e6``)
+        Upper bracket cap forwarded to :func:`get_ri_factor`.
     **ssim_kwargs : object
         Additional keyword arguments forwarded to
         :func:`compute_ssim_elements`. Defaults match the upstream RI-factor
@@ -375,4 +397,4 @@ def get_global_ri_factor(
         C1=C1_last,
         C2=C2_last,
     )
-    return get_ri_factor(pooled)
+    return get_ri_factor(pooled, alpha_max=alpha_max)

--- a/cubic/metrics/microssim/ri_factor.py
+++ b/cubic/metrics/microssim/ri_factor.py
@@ -210,6 +210,14 @@ def _bracket_root(
                 return lo, alpha, f_lo, f_alpha
             lo, f_lo = alpha, f_alpha
             alpha *= 2.0
+        # Powers-of-2 schedule could miss a root in (lo, alpha_max] when
+        # alpha_max isn't itself a power of 2 (e.g., default 1e6 →
+        # last probe is 2**19 = 524288). Probe alpha_max itself before
+        # giving up so the full requested interval is actually covered.
+        if lo < alpha_max:
+            f_cap = _compute_dS_mean(alpha_max, elements)
+            if f_cap <= 0.0:
+                return lo, alpha_max, f_lo, f_cap
         raise RuntimeError(
             "RI factor failed to bracket on the right; input may violate "
             f"fit assumptions or alpha_max={alpha_max} is too small. "
@@ -224,6 +232,13 @@ def _bracket_root(
             return alpha, hi, f_alpha, f_hi
         hi, f_hi = alpha, f_alpha
         alpha *= 0.5
+    # Mirror of the right-side fix: probe alpha_min itself before giving
+    # up so a root in [alpha_min, hi) isn't missed by the powers-of-2
+    # schedule.
+    if hi > alpha_min:
+        f_floor = _compute_dS_mean(alpha_min, elements)
+        if f_floor >= 0.0:
+            return alpha_min, hi, f_floor, f_hi
     raise RuntimeError(
         "RI factor failed to bracket on the left; input may violate "
         f"fit assumptions or alpha_min={alpha_min} is too large. "
@@ -265,11 +280,11 @@ def get_ri_factor(
         calibration sets, heavily mis-normalized predictions).
 
         Note: bracket probes are powers of 2 starting at 2 (rightward) or
-        0.5 (leftward). The extreme probed values are therefore the
-        nearest powers of 2 not exceeding ``alpha_max`` / not falling
-        below ``alpha_min`` (e.g., ``2**19 = 524288`` for
-        ``alpha_max = 1e6`` and ``2**-20 ~= 9.5e-7`` for
-        ``alpha_min = 1e-6``).
+        0.5 (leftward); if the schedule overshoots ``alpha_max`` /
+        undershoots ``alpha_min`` without finding a sign change, the cap
+        itself is probed once before raising so a root in
+        ``(last_probe, alpha_max]`` (or ``[alpha_min, last_probe)``) is
+        not missed.
 
     Returns
     -------

--- a/cubic/metrics/microssim/ri_factor.py
+++ b/cubic/metrics/microssim/ri_factor.py
@@ -25,9 +25,10 @@ Analytical derivative (per-pixel):
 
 ``f(alpha)`` is the mean of ``dS_n/dalpha`` over all flattened element pixels.
 MicroSSIM normalization places the optimum near ``alpha = 1``; we bracket by
-doubling outwards from ``alpha = 1`` (default cap ``1e-3 <= alpha <= 1e6``;
-the upper bound is configurable via the ``alpha_max`` kwarg) and refine with
-bisection terminated on both ``|f(mid)| < 1e-10`` AND ``|hi - lo| < 1e-8``.
+doubling outwards from ``alpha = 1`` (default range ``1e-6 <= alpha <= 1e6``;
+both bounds are configurable via the ``alpha_min`` / ``alpha_max`` kwargs) and
+refine with bisection terminated on both ``|f(mid)| < 1e-10`` AND
+``|hi - lo| < 1e-8``.
 """
 
 from __future__ import annotations
@@ -41,13 +42,26 @@ from .ssim_elements import SSIMElements, compute_ssim_elements
 # conjunctive termination guards both flat-region stalls (pure |f| tol)
 # and tiny-slope spinning (pure x tol).
 _ALPHA_INIT = 1.0
+ALPHA_MIN_DEFAULT = 1e-6
 ALPHA_MAX_DEFAULT = 1e6
-_ALPHA_MIN = 1e-3
 _F_TOL = 1e-10
 _X_TOL = 1e-8
 _INIT_F_TOL = 1e-14
 _ASCENT_SLACK = 1e-12
 _MAX_BISECT_ITERS = 200
+
+
+def _validate_alpha_bounds(alpha_min: float, alpha_max: float) -> None:
+    """Validate that ``(alpha_min, alpha_max)`` brackets ``alpha = 1`` strictly.
+
+    The bracket starts at ``alpha = 1`` and expands by halving leftward /
+    doubling rightward, so any ``alpha_min`` not in ``(0, 1)`` or any
+    ``alpha_max`` not in ``(1, +inf)`` produces a degenerate window.
+    """
+    if not (np.isfinite(alpha_min) and 0.0 < alpha_min < 1.0):
+        raise ValueError(f"alpha_min must be a finite float in (0, 1); got {alpha_min}")
+    if not (np.isfinite(alpha_max) and alpha_max > 1.0):
+        raise ValueError(f"alpha_max must be a finite float > 1; got {alpha_max}")
 
 
 def _compute_S_mean(alpha: float, elements: SSIMElements) -> float:
@@ -153,7 +167,7 @@ def _flatten_elements(elements: SSIMElements) -> SSIMElements:
 
 
 def _bracket_root(
-    elements: SSIMElements, f1: float, alpha_max: float
+    elements: SSIMElements, f1: float, alpha_min: float, alpha_max: float
 ) -> tuple[float, float, float, float]:
     """Find ``(lo, hi)`` with opposite-sign ``f`` values by expanding from 1.
 
@@ -168,6 +182,9 @@ def _bracket_root(
         Flattened SSIM elements (variances / covariance).
     f1 : float
         Value of ``f(1)``; sign decides direction.
+    alpha_min : float
+        Lower bracket cap. Halving expansion stops once ``alpha`` falls
+        below this value without a sign change.
     alpha_max : float
         Upper bracket cap. Doubling expansion stops once ``alpha`` exceeds
         this value without a sign change.
@@ -181,7 +198,7 @@ def _bracket_root(
     Raises
     ------
     RuntimeError
-        If no sign change is found within ``[_ALPHA_MIN, alpha_max]``.
+        If no sign change is found within ``[alpha_min, alpha_max]``.
     """
     if f1 > 0.0:
         # f(1) > 0: root is to the right of 1 — expand by doubling.
@@ -201,7 +218,7 @@ def _bracket_root(
     # f(1) < 0: root is to the left of 1 — expand by halving.
     hi, f_hi = _ALPHA_INIT, f1
     alpha = _ALPHA_INIT * 0.5
-    while alpha >= _ALPHA_MIN:
+    while alpha >= alpha_min:
         f_alpha = _compute_dS_mean(alpha, elements)
         if f_alpha == 0.0 or (f_alpha > 0.0):
             return alpha, hi, f_alpha, f_hi
@@ -209,12 +226,16 @@ def _bracket_root(
         alpha *= 0.5
     raise RuntimeError(
         "RI factor failed to bracket on the left; input may violate "
-        f"fit assumptions. ux shape={elements.ux.shape}"
+        f"fit assumptions or alpha_min={alpha_min} is too large. "
+        f"ux shape={elements.ux.shape}"
     )
 
 
 def get_ri_factor(
-    elements: SSIMElements, *, alpha_max: float = ALPHA_MAX_DEFAULT
+    elements: SSIMElements,
+    *,
+    alpha_min: float = ALPHA_MIN_DEFAULT,
+    alpha_max: float = ALPHA_MAX_DEFAULT,
 ) -> float:
     """Compute the range-invariant factor by bisection on ``dS/dalpha = 0``.
 
@@ -232,15 +253,23 @@ def get_ri_factor(
         taken over all pixels. ``C1`` and ``C2`` are taken from the
         ``elements`` object (callers using :func:`get_global_ri_factor` get
         the last-slice values, matching upstream).
+    alpha_min : float, default=:data:`ALPHA_MIN_DEFAULT` (``1e-6``)
+        Lower bracket cap for the halving expansion. Used when ``pred`` is
+        scaled larger than ``gt`` so the optimum sits below ``1``. The
+        default safely covers most reasonable fits; lower it for heavily
+        up-scaled predictions (``pred ~ 1e6 * gt``).
     alpha_max : float, default=:data:`ALPHA_MAX_DEFAULT` (``1e6``)
         Upper bracket cap for the doubling expansion. The default safely
         covers most reasonable MicroSSIM fits where the optimum sits near
         ``alpha = 1``; raise it for pathological inputs (very small
         calibration sets, heavily mis-normalized predictions).
 
-        Note: bracket probes are powers of 2 starting at 2. The largest
-        probed value is therefore the largest power of 2 not exceeding
-        ``alpha_max`` (e.g., ``2**19 = 524288`` for ``alpha_max = 1e6``).
+        Note: bracket probes are powers of 2 starting at 2 (rightward) or
+        0.5 (leftward). The extreme probed values are therefore the
+        nearest powers of 2 not exceeding ``alpha_max`` / not falling
+        below ``alpha_min`` (e.g., ``2**19 = 524288`` for
+        ``alpha_max = 1e6`` and ``2**-20 ~= 9.5e-7`` for
+        ``alpha_min = 1e-6``).
 
     Returns
     -------
@@ -251,11 +280,13 @@ def get_ri_factor(
     ------
     RuntimeError
         If the bracketing phase fails to find a sign change within
-        ``[1e-3, alpha_max]`` — typical for pathological inputs (constant
-        ground truth with non-constant prediction, or all-zero prediction).
+        ``[alpha_min, alpha_max]`` — typical for pathological inputs
+        (constant ground truth with non-constant prediction, or all-zero
+        prediction).
     ValueError
-        If ``alpha_max <= 1`` (the bracket starts at ``alpha = 1`` and
-        expands rightward, so any cap at or below 1 is degenerate).
+        If ``alpha_min`` is outside ``(0, 1)`` or ``alpha_max`` is outside
+        ``(1, +inf)``. The bracket starts at ``alpha = 1`` and expands
+        outward, so any cap on the wrong side of 1 is degenerate.
 
     Notes
     -----
@@ -264,15 +295,14 @@ def get_ri_factor(
     invariant ``mean(S(alpha*)) >= mean(S(1)) - 1e-12`` is asserted (with
     slack to allow ``alpha = 1`` itself being the optimum).
     """
-    if not (np.isfinite(alpha_max) and alpha_max > 1.0):
-        raise ValueError(f"alpha_max must be a finite float > 1; got {alpha_max}")
+    _validate_alpha_bounds(alpha_min, alpha_max)
     flat = _flatten_elements(elements)
 
     f1 = _compute_dS_mean(_ALPHA_INIT, flat)
     if abs(f1) < _INIT_F_TOL:
         return float(_ALPHA_INIT)
 
-    lo, hi, f_lo, f_hi = _bracket_root(flat, f1, alpha_max)
+    lo, hi, f_lo, f_hi = _bracket_root(flat, f1, alpha_min, alpha_max)
 
     # Bisection refinement. The conjunction of |f| and x tolerances guards
     # both stalling in flat regions and spinning on near-zero slope.
@@ -305,6 +335,7 @@ def get_global_ri_factor(
     gt: np.ndarray,
     pred: np.ndarray,
     *,
+    alpha_min: float = ALPHA_MIN_DEFAULT,
     alpha_max: float = ALPHA_MAX_DEFAULT,
     **ssim_kwargs: object,
 ) -> float:
@@ -325,6 +356,8 @@ def get_global_ri_factor(
         here; pool such inputs at the ``MicroSSIM.fit`` layer.
     pred : numpy.ndarray
         Prediction stack; same shape as ``gt``.
+    alpha_min : float, default=:data:`ALPHA_MIN_DEFAULT` (``1e-6``)
+        Lower bracket cap forwarded to :func:`get_ri_factor`.
     alpha_max : float, default=:data:`ALPHA_MAX_DEFAULT` (``1e6``)
         Upper bracket cap forwarded to :func:`get_ri_factor`.
     **ssim_kwargs : object
@@ -342,14 +375,13 @@ def get_global_ri_factor(
     Raises
     ------
     ValueError
-        If ``alpha_max <= 1`` (see :func:`get_ri_factor`), ``gt`` and
-        ``pred`` differ in shape, or either has ``ndim`` not in
-        ``{2, 3}``.
+        If ``alpha_min`` / ``alpha_max`` are out of range (see
+        :func:`get_ri_factor`), ``gt`` and ``pred`` differ in shape, or
+        either has ``ndim`` not in ``{2, 3}``.
     """
-    # Validate alpha_max up-front so a bad value fails before the
+    # Validate bracket bounds up-front so a bad value fails before the
     # potentially-expensive per-slice compute_ssim_elements loop.
-    if not (np.isfinite(alpha_max) and alpha_max > 1.0):
-        raise ValueError(f"alpha_max must be a finite float > 1; got {alpha_max}")
+    _validate_alpha_bounds(alpha_min, alpha_max)
     if gt.shape != pred.shape:
         raise ValueError(
             f"Ground-truth and prediction arrays must have the same shape "
@@ -407,4 +439,4 @@ def get_global_ri_factor(
         C1=C1_last,
         C2=C2_last,
     )
-    return get_ri_factor(pooled, alpha_max=alpha_max)
+    return get_ri_factor(pooled, alpha_min=alpha_min, alpha_max=alpha_max)

--- a/tests/metrics/microssim/test_micro_ms3im.py
+++ b/tests/metrics/microssim/test_micro_ms3im.py
@@ -187,6 +187,27 @@ def test_ri_factor_without_norm_params_raises():
         MicroMS3IM(ri_factor=0.9)
 
 
+def test_alpha_caps_propagate_through_inheritance():
+    """Alpha caps inherit through ``MicroMS3IM`` and reach fit-time.
+
+    No ``MicroMS3IM.__init__`` override exists, so this test pins the
+    contract that ``alpha_min`` / ``alpha_max`` work uniformly across
+    the class hierarchy (constructor validation + fit forwarding).
+    """
+    # Eager validation propagates through inheritance.
+    with pytest.raises(ValueError, match="alpha_max"):
+        MicroMS3IM(alpha_max=0.5)
+    with pytest.raises(ValueError, match="alpha_min"):
+        MicroMS3IM(alpha_min=1.5)
+
+    # Heavy down-scaled fit fails cleanly when alpha_max is below the optimum.
+    rng = np.random.default_rng(12)
+    gt = rng.random((3, _H, _W)).astype(np.float64)
+    pred = gt * 1e-4
+    with pytest.raises(RuntimeError, match="failed to bracket on the right"):
+        MicroMS3IM(alpha_max=1e3).fit(gt, pred)
+
+
 # --- GPU dispatch ----------------------------------------------------------
 
 

--- a/tests/metrics/microssim/test_micro_ms3im.py
+++ b/tests/metrics/microssim/test_micro_ms3im.py
@@ -176,7 +176,9 @@ def test_score_with_pinned_ri_factor_skips_fit():
     assert pinned._initialized
     score_fitted = fitted.score(gt[0], pred[0])
     score_pinned = pinned.score(gt[0], pred[0])
-    assert abs(score_fitted - score_pinned) < 1e-12
+    # Identical code paths with identical params + inputs must be bit-exact;
+    # a non-zero diff signals an unintended non-determinism in the score path.
+    assert score_fitted == score_pinned
 
 
 def test_ri_factor_without_norm_params_raises():

--- a/tests/metrics/microssim/test_micro_ms3im.py
+++ b/tests/metrics/microssim/test_micro_ms3im.py
@@ -152,6 +152,39 @@ def test_convenience_list_input_returns_list():
     assert len(out) == 3
 
 
+# --- pinned ri_factor (external calibration) -------------------------------
+
+
+def test_score_with_pinned_ri_factor_skips_fit():
+    """``MicroMS3IM(ri_factor=...)`` enables scoring without ``fit()``.
+
+    Inherits the constructor contract from ``MicroSSIM``; this test pins
+    the use case for callers that want to load a per-(model, organelle)
+    RI factor calibrated once and reuse it across all evaluation calls.
+    """
+    gt, pred = _seeded_data()
+    fitted = MicroMS3IM().fit(gt, pred)
+    params = fitted.get_parameters()
+
+    pinned = MicroMS3IM(
+        offset_gt=params["offset_gt"],
+        offset_pred=params["offset_pred"],
+        max_val=params["max_val"],
+        ri_factor=params["ri_factor"],
+    )
+    # No fit() call — score works immediately.
+    assert pinned._initialized
+    score_fitted = fitted.score(gt[0], pred[0])
+    score_pinned = pinned.score(gt[0], pred[0])
+    assert abs(score_fitted - score_pinned) < 1e-12
+
+
+def test_ri_factor_without_norm_params_raises():
+    """``ri_factor=`` alone on ``MicroMS3IM`` is rejected (inherited check)."""
+    with pytest.raises(ValueError, match="offset_pred, offset_gt and max_val"):
+        MicroMS3IM(ri_factor=0.9)
+
+
 # --- GPU dispatch ----------------------------------------------------------
 
 

--- a/tests/metrics/microssim/test_micro_ssim.py
+++ b/tests/metrics/microssim/test_micro_ssim.py
@@ -222,6 +222,22 @@ def test_alpha_max_constructor_propagates_to_fit():
         MicroSSIM(alpha_max=1e3).fit(gt, pred)
 
 
+def test_alpha_max_degenerate_raises_at_construction():
+    """``alpha_max <= 1`` is rejected eagerly in ``__init__``, not at fit-time.
+
+    Catches obvious-bug values (0, 0.5, NaN, ±inf) at the call site instead
+    of after an expensive per-slice element pass.
+    """
+    with pytest.raises(ValueError, match="alpha_max"):
+        MicroSSIM(alpha_max=0.5)
+    with pytest.raises(ValueError, match="alpha_max"):
+        MicroSSIM(alpha_max=1.0)
+    with pytest.raises(ValueError, match="alpha_max"):
+        MicroSSIM(alpha_max=float("nan"))
+    with pytest.raises(ValueError, match="alpha_max"):
+        MicroSSIM(alpha_max=float("inf"))
+
+
 # --- pinned ri_factor (external calibration) -------------------------------
 
 

--- a/tests/metrics/microssim/test_micro_ssim.py
+++ b/tests/metrics/microssim/test_micro_ssim.py
@@ -261,7 +261,9 @@ def test_score_with_pinned_ri_factor_skips_fit():
     assert pinned._initialized
     score_fitted = fitted.score(gt[0], pred[0])
     score_pinned = pinned.score(gt[0], pred[0])
-    assert abs(score_fitted - score_pinned) < 1e-12
+    # Identical code paths with identical params + inputs must be bit-exact;
+    # a non-zero diff signals an unintended non-determinism in the score path.
+    assert score_fitted == score_pinned
 
 
 # --- Convenience function --------------------------------------------------

--- a/tests/metrics/microssim/test_micro_ssim.py
+++ b/tests/metrics/microssim/test_micro_ssim.py
@@ -205,6 +205,49 @@ def test_score_kwargs_forwarded_to_elements():
     assert default_score != bigger_K1_score
 
 
+# --- alpha_max kwarg -------------------------------------------------------
+
+
+def test_alpha_max_constructor_propagates_to_fit():
+    """Low ``alpha_max`` on the constructor surfaces as a fit-time RuntimeError.
+
+    Heavy down-scaled input (alpha* well past 1e3); the bumped default
+    ``alpha_max=1e6`` would handle this, but an explicit low cap must
+    fail loudly instead of silently clipping.
+    """
+    rng = np.random.default_rng(12)
+    gt = rng.random((3, 64, 64)).astype(np.float64)
+    pred = gt * 1e-4
+    with pytest.raises(RuntimeError, match="failed to bracket on the right"):
+        MicroSSIM(alpha_max=1e3).fit(gt, pred)
+
+
+# --- pinned ri_factor (external calibration) -------------------------------
+
+
+def test_score_with_pinned_ri_factor_skips_fit():
+    """Constructor-supplied params + ri_factor enable scoring without fit().
+
+    Use case: load a per-(model, organelle) RI factor calibrated once
+    upstream and reuse it across all evaluation calls without re-fitting.
+    """
+    gt, pred = _seeded_data()
+    fitted = MicroSSIM().fit(gt, pred)
+    params = fitted.get_parameters()
+
+    pinned = MicroSSIM(
+        offset_gt=params["offset_gt"],
+        offset_pred=params["offset_pred"],
+        max_val=params["max_val"],
+        ri_factor=params["ri_factor"],
+    )
+    # No fit() call — score works immediately.
+    assert pinned._initialized
+    score_fitted = fitted.score(gt[0], pred[0])
+    score_pinned = pinned.score(gt[0], pred[0])
+    assert abs(score_fitted - score_pinned) < 1e-12
+
+
 # --- Convenience function --------------------------------------------------
 
 

--- a/tests/metrics/microssim/test_micro_ssim.py
+++ b/tests/metrics/microssim/test_micro_ssim.py
@@ -238,6 +238,27 @@ def test_alpha_max_degenerate_raises_at_construction():
         MicroSSIM(alpha_max=float("inf"))
 
 
+def test_alpha_min_constructor_propagates_to_fit():
+    """High ``alpha_min`` on the constructor surfaces as a fit-time RuntimeError.
+
+    Heavy up-scaled input (alpha* well below 1e-3); the bumped default
+    ``alpha_min=1e-6`` would handle this, but an explicit high floor must
+    fail loudly instead of silently clipping.
+    """
+    rng = np.random.default_rng(21)
+    gt = rng.random((3, 64, 64)).astype(np.float64)
+    pred = gt * 1e5
+    with pytest.raises(RuntimeError, match="failed to bracket on the left"):
+        MicroSSIM(alpha_min=1e-3).fit(gt, pred)
+
+
+def test_alpha_min_degenerate_raises_at_construction():
+    """``alpha_min`` outside ``(0, 1)`` is rejected eagerly in ``__init__``."""
+    for bad in (0.0, 1.0, -1.0, 1.5, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="alpha_min"):
+            MicroSSIM(alpha_min=bad)
+
+
 # --- pinned ri_factor (external calibration) -------------------------------
 
 

--- a/tests/metrics/microssim/test_ri_factor.py
+++ b/tests/metrics/microssim/test_ri_factor.py
@@ -74,9 +74,10 @@ def test_constant_gt_noisy_pred_no_silent_nan() -> None:
 
     With gt constant, ``ux*uy != 0`` but ``vx == vxy == 0`` (or nearly so);
     ``vy`` is small but positive. Empirically the derivative still changes
-    sign inside ``[1e-3, 1e3]`` for this configuration, so we accept either
-    a finite positive ``alpha*`` (with the ascent invariant satisfied) or a
-    clean ``RuntimeError`` from bracket failure — never a silent NaN / inf.
+    sign inside the default bracket window for this configuration, so we
+    accept either a finite positive ``alpha*`` (with the ascent invariant
+    satisfied) or a clean ``RuntimeError`` from bracket failure — never a
+    silent NaN / inf.
     """
     rng = np.random.default_rng(2)
     gt = np.full((16, 16), 5.0, dtype=np.float64)

--- a/tests/metrics/microssim/test_ri_factor.py
+++ b/tests/metrics/microssim/test_ri_factor.py
@@ -461,3 +461,48 @@ def test_global_ri_factor_rejects_bad_alpha_min_before_per_slice_pass() -> None:
     for bad in (0.0, 1.0, -0.5, 2.0, float("nan"), float("inf")):
         with pytest.raises(ValueError, match="alpha_min"):
             get_global_ri_factor(gt, pred, alpha_min=bad)
+
+
+# -- Bracket boundary: cap probed once before raising ----------------------
+
+
+def test_alpha_max_cap_probed_when_loop_overshoots() -> None:
+    """``alpha_max`` itself is probed once when the powers-of-2 schedule overshoots.
+
+    Setup: ``pred = gt * 0.833`` puts ``alpha*`` near ``1.2``; with
+    ``alpha_max = 1.5``, the doubling loop's first probe ``alpha = 2.0``
+    already overshoots ``alpha_max`` and the loop exits without entering
+    its body. Pre-fix, this raised ``RuntimeError`` despite a root
+    existing in ``(1, 1.5]``. Post-fix, the cap probe at ``1.5`` covers
+    the gap and the bracket succeeds.
+    """
+    rng = np.random.default_rng(30)
+    gt = rng.random((48, 48)).astype(np.float64)
+    pred = gt * 0.833  # alpha* ~ 1.2 (between 1.0 and the first would-be probe at 2.0)
+    dr = float(gt.max() - gt.min())
+    elements = compute_ssim_elements(
+        gt, pred, data_range=dr, gaussian_weights=False, win_size=7, crop=True
+    )
+    alpha = get_ri_factor(elements, alpha_max=1.5)
+    assert np.isfinite(alpha)
+    assert 1.0 <= alpha <= 1.5, f"expected root in [1.0, 1.5]; got {alpha}"
+
+
+def test_alpha_min_cap_probed_when_loop_undershoots() -> None:
+    """Mirror: ``alpha_min`` itself is probed once when halving undershoots.
+
+    ``pred = gt * 1.2`` puts ``alpha*`` near ``0.833``; with
+    ``alpha_min = 0.6``, the halving loop's first probe ``alpha = 0.5``
+    already undershoots ``alpha_min``. Pre-fix this raised; post-fix the
+    cap probe at ``0.6`` covers the gap.
+    """
+    rng = np.random.default_rng(31)
+    gt = rng.random((48, 48)).astype(np.float64)
+    pred = gt * 1.2  # alpha* ~ 0.833 (between 0.5 and 1.0)
+    dr = float(gt.max() - gt.min())
+    elements = compute_ssim_elements(
+        gt, pred, data_range=dr, gaussian_weights=False, win_size=7, crop=True
+    )
+    alpha = get_ri_factor(elements, alpha_min=0.6)
+    assert np.isfinite(alpha)
+    assert 0.6 <= alpha <= 1.0, f"expected root in [0.6, 1.0]; got {alpha}"

--- a/tests/metrics/microssim/test_ri_factor.py
+++ b/tests/metrics/microssim/test_ri_factor.py
@@ -97,11 +97,12 @@ def test_constant_gt_noisy_pred_no_silent_nan() -> None:
 
 
 def test_extreme_scaling_bracket_failure() -> None:
-    """Heavy uniform scaling pushes the optimum below the bracket floor.
+    """Tight ``alpha_min`` raises cleanly when the optimum falls below it.
 
-    ``pred = 1e5 * gt`` puts the optimum at alpha ~ 1e-5, well below the
-    bracket cap ``_ALPHA_MIN = 1e-3``. Verifies the bisection raises a clean
-    ``RuntimeError`` instead of converging to a nonsensical value or NaN.
+    ``pred = 1e5 * gt`` puts the optimum at alpha ~ 1e-5. With an explicit
+    ``alpha_min = 1e-3`` (the pre-PR default), the bracket cannot reach
+    the optimum and raises a clean ``RuntimeError`` instead of converging
+    to a nonsensical value or NaN.
     """
     rng = np.random.default_rng(10)
     gt = rng.random((32, 32)).astype(np.float64)
@@ -111,7 +112,7 @@ def test_extreme_scaling_bracket_failure() -> None:
         gt, pred, data_range=dr, gaussian_weights=False, win_size=7, crop=True
     )
     with pytest.raises(RuntimeError, match="RI factor failed to bracket"):
-        get_ri_factor(elements)
+        get_ri_factor(elements, alpha_min=1e-3)
 
 
 def test_all_zero_pred_no_silent_nan() -> None:
@@ -195,7 +196,7 @@ def test_bisection_terminates_quickly() -> None:
     # accidentally already satisfies |f(1)| ~ 0.
     if abs(f1) < 1e-14:
         pytest.skip("f(1) already at machine zero; iter count not meaningful")
-    lo, hi, f_lo, f_hi = _bracket_root(flat, f1, alpha_max=1e3)
+    lo, hi, f_lo, f_hi = _bracket_root(flat, f1, alpha_min=1e-3, alpha_max=1e3)
 
     iters = 0
     mid = 0.5 * (lo + hi)
@@ -387,3 +388,76 @@ def test_global_ri_factor_rejects_bad_alpha_max_before_per_slice_pass() -> None:
     for bad in (0.5, 1.0, float("nan"), float("inf")):
         with pytest.raises(ValueError, match="alpha_max"):
             get_global_ri_factor(gt, pred, alpha_max=bad)
+
+
+# -- alpha_min kwarg (mirror of alpha_max) ---------------------------------
+
+
+def test_alpha_min_outside_unit_interval_raises() -> None:
+    """``alpha_min`` outside ``(0, 1)`` is rejected up-front."""
+    rng = np.random.default_rng(20)
+    gt = rng.random((32, 32)).astype(np.float64)
+    elements = compute_ssim_elements(
+        gt,
+        gt,
+        data_range=float(gt.max() - gt.min()),
+        gaussian_weights=False,
+        win_size=7,
+        crop=True,
+    )
+    for bad in (0.0, 1.0, -1.0, 1.5, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="alpha_min"):
+            get_ri_factor(elements, alpha_min=bad)
+
+
+def test_alpha_min_default_lifts_left_bracket() -> None:
+    """Heavy up-scaling (alpha* ~ 1e-5) now succeeds at the default floor.
+
+    With the old ``_ALPHA_MIN = 1e-3`` this would have raised
+    ``RuntimeError("RI factor failed to bracket on the left ...")``;
+    the bumped default (``1e-6``) keeps the fit working on this case.
+    """
+    rng = np.random.default_rng(21)
+    gt = rng.random((32, 32)).astype(np.float64)
+    pred = gt * 1e5  # optimum sits near alpha ~ 1e-5
+    dr = float(gt.max() - gt.min())
+    elements = compute_ssim_elements(
+        gt, pred, data_range=dr, gaussian_weights=False, win_size=7, crop=True
+    )
+    alpha = get_ri_factor(elements)  # default alpha_min=1e-6
+    assert np.isfinite(alpha)
+    assert alpha < 1e-3  # would have hit the old 1e-3 floor
+
+
+def test_alpha_min_above_optimum_raises() -> None:
+    """Explicit high floor forces a clean bracket failure (no silent clip)."""
+    rng = np.random.default_rng(21)
+    gt = rng.random((32, 32)).astype(np.float64)
+    pred = gt * 1e5
+    dr = float(gt.max() - gt.min())
+    elements = compute_ssim_elements(
+        gt, pred, data_range=dr, gaussian_weights=False, win_size=7, crop=True
+    )
+    with pytest.raises(RuntimeError, match="failed to bracket on the left"):
+        get_ri_factor(elements, alpha_min=1e-3)
+
+
+def test_global_ri_factor_forwards_alpha_min() -> None:
+    """``get_global_ri_factor`` forwards ``alpha_min`` to ``get_ri_factor``."""
+    rng = np.random.default_rng(21)
+    gt = rng.random((3, 32, 32)).astype(np.float64)
+    pred = gt * 1e5
+    with pytest.raises(RuntimeError, match="failed to bracket on the left"):
+        get_global_ri_factor(gt, pred, alpha_min=1e-3)
+    # Default floor recovers a finite positive alpha.
+    alpha = get_global_ri_factor(gt, pred)
+    assert np.isfinite(alpha) and alpha < 1e-3
+
+
+def test_global_ri_factor_rejects_bad_alpha_min_before_per_slice_pass() -> None:
+    """``get_global_ri_factor`` validates ``alpha_min`` before the element loop."""
+    gt = np.zeros((3, 32, 32))
+    pred = np.zeros((3, 32, 32))
+    for bad in (0.0, 1.0, -0.5, 2.0, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="alpha_min"):
+            get_global_ri_factor(gt, pred, alpha_min=bad)

--- a/tests/metrics/microssim/test_ri_factor.py
+++ b/tests/metrics/microssim/test_ri_factor.py
@@ -372,3 +372,18 @@ def test_global_ri_factor_forwards_alpha_max() -> None:
     # Default cap recovers a finite positive alpha.
     alpha = get_global_ri_factor(gt, pred)
     assert np.isfinite(alpha) and alpha > 1e3
+
+
+def test_global_ri_factor_rejects_bad_alpha_max_before_per_slice_pass() -> None:
+    """``get_global_ri_factor`` validates ``alpha_max`` before the element loop.
+
+    A bad ``alpha_max`` should surface immediately, not after N expensive
+    ``compute_ssim_elements`` calls. Use a stack large enough that a
+    deferred check would be observable in wallclock; here we just confirm
+    the error type / message matches the eager-validation contract.
+    """
+    gt = np.zeros((3, 32, 32))
+    pred = np.zeros((3, 32, 32))
+    for bad in (0.5, 1.0, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="alpha_max"):
+            get_global_ri_factor(gt, pred, alpha_max=bad)

--- a/tests/metrics/microssim/test_ri_factor.py
+++ b/tests/metrics/microssim/test_ri_factor.py
@@ -194,7 +194,7 @@ def test_bisection_terminates_quickly() -> None:
     # accidentally already satisfies |f(1)| ~ 0.
     if abs(f1) < 1e-14:
         pytest.skip("f(1) already at machine zero; iter count not meaningful")
-    lo, hi, f_lo, f_hi = _bracket_root(flat, f1)
+    lo, hi, f_lo, f_hi = _bracket_root(flat, f1, alpha_max=1e3)
 
     iters = 0
     mid = 0.5 * (lo + hi)
@@ -301,3 +301,73 @@ def test_global_ri_factor_rejects_ndim_4() -> None:
     pred = np.zeros((2, 3, 32, 32))
     with pytest.raises(ValueError, match="ndim"):
         get_global_ri_factor(gt, pred)
+
+
+# -- alpha_max kwarg --------------------------------------------------------
+
+
+def test_alpha_max_below_one_raises() -> None:
+    """``alpha_max <= 1`` is degenerate (bracket starts at 1) — must raise."""
+    rng = np.random.default_rng(11)
+    gt = rng.random((32, 32)).astype(np.float64)
+    pred = gt.copy()
+    dr = float(gt.max() - gt.min())
+    elements = compute_ssim_elements(
+        gt, pred, data_range=dr, gaussian_weights=False, win_size=7, crop=True
+    )
+    with pytest.raises(ValueError, match="alpha_max"):
+        get_ri_factor(elements, alpha_max=1.0)
+    with pytest.raises(ValueError, match="alpha_max"):
+        get_ri_factor(elements, alpha_max=0.5)
+
+
+def test_alpha_max_default_lifts_right_bracket() -> None:
+    """Heavy down-scaling (alpha* ~ 1e4) now succeeds at the default cap.
+
+    With the old ``alpha_max = 1e3`` default this would have raised
+    ``RuntimeError("RI factor failed to bracket on the right ...")``;
+    the bumped default (``1e6``) keeps the fit working on this case.
+    """
+    rng = np.random.default_rng(12)
+    gt = rng.random((32, 32)).astype(np.float64)
+    pred = gt * 1e-4  # optimum sits near alpha ~ 1e4
+    dr = float(gt.max() - gt.min())
+    elements = compute_ssim_elements(
+        gt, pred, data_range=dr, gaussian_weights=False, win_size=7, crop=True
+    )
+    alpha = get_ri_factor(elements)  # default alpha_max=1e6
+    assert np.isfinite(alpha)
+    assert alpha > 1e3  # would have hit the old 1e3 cap
+
+
+def test_alpha_max_below_optimum_raises() -> None:
+    """Explicit low cap forces a clean bracket failure (no silent clip).
+
+    Same heavy down-scaling input as the previous test; passing
+    ``alpha_max=1e3`` reproduces the failure mode of the old default.
+    """
+    rng = np.random.default_rng(12)
+    gt = rng.random((32, 32)).astype(np.float64)
+    pred = gt * 1e-4
+    dr = float(gt.max() - gt.min())
+    elements = compute_ssim_elements(
+        gt, pred, data_range=dr, gaussian_weights=False, win_size=7, crop=True
+    )
+    with pytest.raises(RuntimeError, match="failed to bracket on the right"):
+        get_ri_factor(elements, alpha_max=1e3)
+
+
+def test_global_ri_factor_forwards_alpha_max() -> None:
+    """``get_global_ri_factor`` forwards ``alpha_max`` to ``get_ri_factor``.
+
+    Same heavy down-scaled stack used for the unit test; explicit low cap
+    must propagate and raise.
+    """
+    rng = np.random.default_rng(12)
+    gt = rng.random((3, 32, 32)).astype(np.float64)
+    pred = gt * 1e-4
+    with pytest.raises(RuntimeError, match="failed to bracket on the right"):
+        get_global_ri_factor(gt, pred, alpha_max=1e3)
+    # Default cap recovers a finite positive alpha.
+    alpha = get_global_ri_factor(gt, pred)
+    assert np.isfinite(alpha) and alpha > 1e3


### PR DESCRIPTION
## Summary
- Adds `alpha_min` and `alpha_max` kwargs to `get_ri_factor` / `get_global_ri_factor` / `MicroSSIM.__init__` so callers can lift / lower the bracket caps for pathological fits without monkey-patching internals.
- Bumps the defaults symmetrically: `alpha_max` 1e3 → 1e6 (covers heavily down-scaled predictions, α\* > 1e3) and `alpha_min` 1e-3 → 1e-6 (covers heavily up-scaled predictions, α\* < 1e-3).
- Documents the pre-existing `MicroSSIM(ri_factor=...)` / `MicroMS3IM(ri_factor=...)` constructor path with tests pinning the use case: load per-(model, organelle) α calibrated once, reuse across all evaluation calls — no re-fit.
- Re-exports `ALPHA_MIN_DEFAULT` and `ALPHA_MAX_DEFAULT` from `cubic.metrics.microssim` so callers can reference the cap defaults at a stable import path.
- Validates bounds eagerly in `MicroSSIM.__init__` and `get_global_ri_factor` (out-of-range / NaN / ±inf raise immediately instead of after an expensive per-slice element pass). Shared `_validate_alpha_bounds` helper enforces the same contract everywhere.
- All new kwargs are keyword-only (`*,` marker) to prevent silent positional misuse.

## Test plan
- [x] `pytest tests/metrics/microssim/` — 132 passed, 1 skipped
- [x] `pytest tests/metrics/` — full metrics suite green (no regression in adjacent metrics)
- [x] `ruff check`, `ruff format --check`, `mypy cubic/` clean
- [x] Upstream parity tests still pass (default-cap bumps don't shift golden α near 1)
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)