### PR TITLE
fix(segmentation): use np.isin in clear_border (np.in1d removed in numpy ≥2.2)

### DIFF
--- a/cubic/segmentation/_clear_border.py
+++ b/cubic/segmentation/_clear_border.py
@@ -117,7 +117,7 @@ def clear_border(
     indices = xp.arange(number + 1)
 
     # mask all label indices that are connected to borders
-    label_mask = np.in1d(indices, borders_indices)
+    label_mask = np.isin(indices, borders_indices)
     # create mask for pixels to clear
     mask = label_mask[labels.reshape(-1)].reshape(labels.shape)
 


### PR DESCRIPTION
## Summary

`cubic/segmentation/_clear_border.py:120` calls `np.in1d`, which was deprecated in numpy 1.25 and **removed in numpy 2.2**. Replaces with `np.isin`, the drop-in successor.

For the 1-D `indices = np.arange(number + 1)` array used here, the two functions are behaviorally identical (`np.in1d` always flattens its output; `np.isin` preserves input shape — both produce the same 1-D mask when the input is already 1-D).

## Test plan

- [x] All 3 existing `clear_border` tests pass (`tests/segmentation/test_clear_border.py`)
- [x] Manual smoke test: a border-touching label is cleared, an interior label is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Use np.isin instead of removed np.in1d in clear_border to restore compatibility with NumPy 2.2 and later.