### PR TITLE
fix(segmentation): handle empty FOVs + migrate off deprecated skimage min_size=

### DIFF
--- a/cubic/segmentation/segment_utils.py
+++ b/cubic/segmentation/segment_utils.py
@@ -95,24 +95,48 @@ def downscale_and_filter(
 def check_labeled_binary(image):
     """Check if the given image is a labeled image.
 
+    Raises ``TypeError`` if the input is not integer-typed. Empty FOVs
+    (constant images, e.g. all-zero label masks) are accepted silently —
+    downstream cleanup steps are no-ops on them and crashing here would
+    require every caller to pre-check.
+
     Parameters
     ----------
     image : ndarray
         The image to be checked.
 
-    Returns
-    -------
-    None
-
     """
-    assert np.issubdtype(image.dtype, np.integer), "Image must be of integer type."
+    if not np.issubdtype(image.dtype, np.integer):
+        raise TypeError(f"Image must be of integer type, got {image.dtype}.")
 
     unique_values = np.unique(image)
-    assert len(unique_values) > 1, "Image is constant."
     if len(unique_values) == 2:
         warnings.warn(
             "Only one label was provided in the image. Make sure to label components first."
         )
+
+
+def _remove_small_objects(label_img: np.ndarray, min_size: int) -> np.ndarray:
+    """Remove objects smaller than ``min_size`` across skimage/cucim API drift.
+
+    skimage 0.26 deprecated ``min_size`` in favor of ``max_size`` (with
+    inverted threshold semantics: ``max_size=N`` removes objects with
+    size ≤ N, while ``min_size=N`` removed size < N — so the equivalent
+    is ``max_size=min_size - 1``). cucim still uses ``min_size``. Dispatch
+    per backend instead of going through the cubic.skimage proxy.
+    """
+    if get_device(label_img) == "GPU":
+        from cucim.skimage.morphology import remove_small_objects as _rso
+
+        return _rso(label_img, min_size=min_size)
+
+    import inspect
+
+    from skimage.morphology import remove_small_objects as _rso
+
+    if "max_size" in inspect.signature(_rso).parameters:
+        return _rso(label_img, max_size=min_size - 1)
+    return _rso(label_img, min_size=min_size)
 
 
 def cleanup_segmentation(
@@ -127,8 +151,7 @@ def cleanup_segmentation(
 
     # first 3 transforms preserve labels
     if min_obj_size is not None:
-        # min_obj_size = to_device(min_obj_size, get_device(label_image))
-        label_img = morphology.remove_small_objects(label_img, min_size=min_obj_size)
+        label_img = _remove_small_objects(label_img, min_size=min_obj_size)
 
     if max_obj_size is not None:
         label_img = remove_large_objects(label_img, max_size=max_obj_size)
@@ -211,8 +234,7 @@ def remove_large_objects(label_image: np.ndarray, max_size: int = 100000) -> np.
 def remove_small_objects(label_image: np.ndarray, min_size: int = 500) -> np.ndarray:
     """Remove objects with volume below specified threshold."""
     check_labeled_binary(label_image)
-    label_image = morphology.remove_small_objects(label_image, min_size=min_size)
-    return label_image
+    return _remove_small_objects(label_image, min_size=min_size)
 
 
 def clear_xy_borders(label_image: np.ndarray, buffer_size: int = 0) -> np.ndarray:

--- a/cubic/segmentation/segment_utils.py
+++ b/cubic/segmentation/segment_utils.py
@@ -142,7 +142,7 @@ def _remove_small_objects(label_img: np.ndarray, min_size: int) -> np.ndarray:
     if get_device(label_img) == "GPU":
         return _cu_morphology.remove_small_objects(label_img, min_size=min_size)
     if _SKIMAGE_USES_MAX_SIZE:
-        return _sk_morphology.remove_small_objects(label_img, max_size=min_size - 1)
+        return _sk_morphology.remove_small_objects(label_img, max_size=min_size - 1)  # type: ignore[call-arg]
     return _sk_morphology.remove_small_objects(label_img, min_size=min_size)
 
 
@@ -156,7 +156,7 @@ def _remove_small_holes(mask: np.ndarray, area_threshold: int) -> np.ndarray:
     if get_device(mask) == "GPU":
         return _cu_morphology.remove_small_holes(mask, area_threshold=area_threshold)
     if _SKIMAGE_USES_MAX_SIZE:
-        return _sk_morphology.remove_small_holes(mask, max_size=area_threshold)
+        return _sk_morphology.remove_small_holes(mask, max_size=area_threshold)  # type: ignore[call-arg]
     return _sk_morphology.remove_small_holes(mask, area_threshold=area_threshold)
 
 

--- a/cubic/segmentation/segment_utils.py
+++ b/cubic/segmentation/segment_utils.py
@@ -1,10 +1,17 @@
 """Implement pre- and post-processing for segmentation."""
 
+import inspect
 import warnings
 from collections.abc import Sequence
 
 import numpy as np
+from skimage import morphology as _sk_morphology
 from skimage.segmentation import watershed
+
+try:
+    from cucim.skimage import morphology as _cu_morphology
+except ImportError:  # cucim is an optional GPU-only dep
+    _cu_morphology = None  # type: ignore[assignment]
 
 from ..cuda import asnumpy, to_device, get_device
 from ..skimage import feature, filters, transform, morphology
@@ -116,27 +123,41 @@ def check_labeled_binary(image):
         )
 
 
+# skimage 0.26 deprecated `min_size` / `area_threshold` on remove_small_objects
+# / remove_small_holes in favor of `max_size`. cucim 26.02 still uses the old
+# names. Detect once at import which kwarg the local skimage accepts; the
+# helpers below dispatch per device.
+_SKIMAGE_USES_MAX_SIZE: bool = (
+    "max_size" in inspect.signature(_sk_morphology.remove_small_objects).parameters
+)
+
+
 def _remove_small_objects(label_img: np.ndarray, min_size: int) -> np.ndarray:
     """Remove objects smaller than ``min_size`` across skimage/cucim API drift.
 
-    skimage 0.26 deprecated ``min_size`` in favor of ``max_size`` (with
-    inverted threshold semantics: ``max_size=N`` removes objects with
-    size ≤ N, while ``min_size=N`` removed size < N — so the equivalent
-    is ``max_size=min_size - 1``). cucim still uses ``min_size``. Dispatch
-    per backend instead of going through the cubic.skimage proxy.
+    skimage 0.26 ``max_size=N`` removes objects of size ≤ N; old ``min_size=N``
+    removed size < N. Pass ``max_size=min_size - 1`` to preserve the old
+    "keep size ≥ min_size" semantics. cucim still uses ``min_size``.
     """
     if get_device(label_img) == "GPU":
-        from cucim.skimage.morphology import remove_small_objects as _rso
+        return _cu_morphology.remove_small_objects(label_img, min_size=min_size)
+    if _SKIMAGE_USES_MAX_SIZE:
+        return _sk_morphology.remove_small_objects(label_img, max_size=min_size - 1)
+    return _sk_morphology.remove_small_objects(label_img, min_size=min_size)
 
-        return _rso(label_img, min_size=min_size)
 
-    import inspect
+def _remove_small_holes(mask: np.ndarray, area_threshold: int) -> np.ndarray:
+    """Fill holes smaller than ``area_threshold`` across skimage/cucim API drift.
 
-    from skimage.morphology import remove_small_objects as _rso
-
-    if "max_size" in inspect.signature(_rso).parameters:
-        return _rso(label_img, max_size=min_size - 1)
-    return _rso(label_img, min_size=min_size)
+    skimage 0.26 renamed ``area_threshold`` → ``max_size`` with identical
+    semantics (no off-by-one shift, unlike ``remove_small_objects``). cucim
+    still uses ``area_threshold``.
+    """
+    if get_device(mask) == "GPU":
+        return _cu_morphology.remove_small_holes(mask, area_threshold=area_threshold)
+    if _SKIMAGE_USES_MAX_SIZE:
+        return _sk_morphology.remove_small_holes(mask, max_size=area_threshold)
+    return _sk_morphology.remove_small_holes(mask, area_threshold=area_threshold)
 
 
 def cleanup_segmentation(
@@ -163,9 +184,7 @@ def cleanup_segmentation(
     if max_hole_size is not None:
         for label_id in np.unique(label_img)[1:]:
             mask = label_img == label_id
-            filled_mask = morphology.remove_small_holes(
-                mask, area_threshold=max_hole_size
-            )
+            filled_mask = _remove_small_holes(mask, area_threshold=max_hole_size)
             label_img[filled_mask] = label_id
 
     return label(label_img).astype(np.uint16)
@@ -446,8 +465,8 @@ def fill_holes_slicer(
                 for i in range(binary.shape[axis]):
                     slicers[axis] = slice(i, i + 1)
                     binary_slice = binary[tuple(slicers)]
-                    filled_slice = morphology.remove_small_holes(
-                        binary_slice, area_threshold
+                    filled_slice = _remove_small_holes(
+                        binary_slice, area_threshold=area_threshold
                     )
                     if filled_slice.shape != binary_slice.shape:
                         raise ValueError(


### PR DESCRIPTION
## Summary

Two unrelated cleanups around `cleanup_segmentation`:

1. **Empty FOVs no longer crash.** `check_labeled_binary` previously did `assert len(unique_values) > 1, \"Image is constant.\"` — so an all-zero label mask (a legitimate \"no cells detected\" FOV) crashed mid-pipeline with `AssertionError`, and `assert` is stripped under `python -O` anyway. Drop that check (downstream steps are no-ops on constant images) and convert the dtype `assert` to a proper `TypeError`. The single-label `UserWarning` stays.

2. **No more `min_size=` deprecation noise.** `skimage.morphology.remove_small_objects` deprecated `min_size=` in 0.26 in favor of `max_size=` (with inverted threshold semantics — removal target is 0.28). cucim 26.02 still uses `min_size=`. Added a tiny `_remove_small_objects` compat helper that bypasses the `cubic.skimage` proxy for this one call and dispatches per device with the right kwarg: `max_size=min_size - 1` for skimage ≥0.26 (preserves the old \"keep size ≥ min_size\" semantics), `min_size=` for cucim and older skimage. Both `cleanup_segmentation` and the public `remove_small_objects` wrapper route through it.

## Test plan

- [x] Empty FOV (all-zero label mask) round-trips through `cleanup_segmentation` with `min_obj_size`/`border_buffer_size` and returns unchanged
- [x] `check_labeled_binary(float32)` now raises `TypeError` (was `AssertionError`)
- [x] `cleanup_segmentation` on a real label image with one below-threshold and one above-threshold object emits no `FutureWarning` and removes the small one
- [x] GPU path (CuPy input) still works via cucim with `min_size=`
- [x] Existing `tests/segmentation/test_clear_border.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle empty field-of-view label masks without errors and adapt small-object removal to API changes in skimage and cucim.

Bug Fixes:
- Allow constant (e.g., all-zero) labeled images to pass through segmentation checks without raising, while still validating integer dtypes with a proper TypeError.

Enhancements:
- Introduce a backend-aware helper for removing small objects that transparently handles skimage's min_size/max_size API change and routes GPU inputs through cucim.
- Route segmentation cleanup and the public remove_small_objects helper through the new compatibility function to avoid deprecation warnings and keep behavior consistent across backends.