### PR TITLE
fix(metrics): return NaN when FSC/FRC curve never legitimately crosses threshold

### DIFF
--- a/cubic/metrics/spectral/analysis.py
+++ b/cubic/metrics/spectral/analysis.py
@@ -394,11 +394,24 @@ class FourierCorrelationAnalysis(object):
             difference = y - thr
             crossings = np.where(difference <= 0)[0]
             if len(crossings) == 0:
-                return None  # No threshold crossing found
-            return x[crossings[0] - 1] if crossings[0] > 0 else x[0]
+                # Never crosses the threshold — resolution is beyond Nyquist
+                # (or the prediction is so close to GT that FSC stays above
+                # threshold everywhere). No measurable resolution: return NaN
+                # rather than reporting Nyquist as a floor.
+                return None
+            if crossings[0] == 0:
+                # Curve starts already below threshold at the lowest measured
+                # frequency — typical of predictions with no meaningful
+                # correlation to GT. There is no above-to-below crossing to
+                # report; fmin started here would wander into extrapolated
+                # territory and yield absurd roots (e.g. negative or near-zero,
+                # producing million-µm resolutions). Return NaN.
+                return None
+            return x[crossings[0] - 1]
 
+        freqs = data_set.correlation["frequency"]
         fit_start = first_guess(
-            data_set.correlation["frequency"],
+            freqs,
             data_set.correlation["curve-fit"],
             np.mean(data_set.resolution["threshold"]),
         )
@@ -419,6 +432,17 @@ class FourierCorrelationAnalysis(object):
         root = optimize.fmin(
             pdiff2 if criterion == "fixed" else pdiff1, fit_start, disp=disp
         )[0]
+
+        # fmin is unbounded; reject roots that landed outside the measured
+        # frequency range (extrapolation territory where the spline can
+        # produce spurious threshold crossings). Resolution = 2*spacing/root
+        # blows up for root ≈ 0 and is meaningless for root < 0 or root > 1.
+        if not (freqs[0] <= root <= freqs[-1]):
+            data_set.resolution["resolution-point"] = (np.nan, np.nan)
+            data_set.resolution["criterion"] = criterion
+            data_set.resolution["resolution"] = np.nan
+            data_set.resolution["spacing"] = self.spacing
+            return data_set
 
         data_set.resolution["resolution-point"] = (frc_eq(root), root)
         data_set.resolution["criterion"] = criterion

--- a/cubic/metrics/spectral/analysis.py
+++ b/cubic/metrics/spectral/analysis.py
@@ -391,13 +391,15 @@ class FourierCorrelationAnalysis(object):
             return abs(frc_eq(x) - threshold)
 
         def first_guess(x, y, thr):
+            # Returns ``None`` when no meaningful seed exists. The caller
+            # interprets that as "no measurable resolution" and sets
+            # ``resolution = NaN``.
             difference = y - thr
             crossings = np.where(difference <= 0)[0]
             if len(crossings) == 0:
                 # Never crosses the threshold — resolution is beyond Nyquist
                 # (or the prediction is so close to GT that FSC stays above
-                # threshold everywhere). No measurable resolution: return NaN
-                # rather than reporting Nyquist as a floor.
+                # threshold everywhere). No measurable resolution.
                 return None
             if crossings[0] == 0:
                 # Curve starts already below threshold at the lowest measured
@@ -405,7 +407,7 @@ class FourierCorrelationAnalysis(object):
                 # correlation to GT. There is no above-to-below crossing to
                 # report; fmin started here would wander into extrapolated
                 # territory and yield absurd roots (e.g. negative or near-zero,
-                # producing million-µm resolutions). Return NaN.
+                # producing million-µm resolutions).
                 return None
             return x[crossings[0] - 1]
 

--- a/cubic/segmentation/segment_utils.py
+++ b/cubic/segmentation/segment_utils.py
@@ -140,6 +140,11 @@ def _remove_small_objects(label_img: np.ndarray, min_size: int) -> np.ndarray:
     "keep size ≥ min_size" semantics. cucim still uses ``min_size``.
     """
     if get_device(label_img) == "GPU":
+        if _cu_morphology is None:
+            raise ImportError(
+                "cucim is required to process GPU arrays but is not installed; "
+                "install cubic with the GPU extras or move the input to CPU."
+            )
         return _cu_morphology.remove_small_objects(label_img, min_size=min_size)
     if _SKIMAGE_USES_MAX_SIZE:
         return _sk_morphology.remove_small_objects(label_img, max_size=min_size - 1)  # type: ignore[call-arg]
@@ -154,6 +159,11 @@ def _remove_small_holes(mask: np.ndarray, area_threshold: int) -> np.ndarray:
     still uses ``area_threshold``.
     """
     if get_device(mask) == "GPU":
+        if _cu_morphology is None:
+            raise ImportError(
+                "cucim is required to process GPU arrays but is not installed; "
+                "install cubic with the GPU extras or move the input to CPU."
+            )
         return _cu_morphology.remove_small_holes(mask, area_threshold=area_threshold)
     if _SKIMAGE_USES_MAX_SIZE:
         return _sk_morphology.remove_small_holes(mask, max_size=area_threshold)  # type: ignore[call-arg]

--- a/tests/metrics/spectral/test_frc.py
+++ b/tests/metrics/spectral/test_frc.py
@@ -743,3 +743,88 @@ def test_preprocess_images_centers_before_padding_non_cubic_input() -> None:
         f"centered reference — preprocess_images must mean-center before "
         f"pad_image_to_cube"
     )
+
+
+def test_resolution_returns_nan_when_curve_below_threshold() -> None:
+    """FSC/FRC curves that never start above the threshold must yield NaN.
+
+    Regression guard: predictions with near-zero correlation to GT
+    produce curves that sit below 0.143 from the lowest measured
+    frequency. ``first_guess`` previously returned ``x[0]`` in that
+    case, feeding an unbounded ``fmin`` that wandered into extrapolated
+    territory and produced absurd roots (negative or near-zero),
+    yielding resolutions of millions of µm via ``2 * spacing / root``.
+    The fix returns ``None`` (→ NaN) when the curve starts already
+    below the threshold and also rejects fmin roots outside the data's
+    frequency range.
+    """
+    freqs = np.linspace(0.05, 1.0, 50)
+
+    # Case 1: below-threshold-everywhere curve (zero-correlation prediction).
+    below = FourierCorrelationData()
+    below.correlation["frequency"] = freqs
+    below.correlation["correlation"] = 0.02 + 0.05 * np.random.default_rng(
+        0
+    ).standard_normal(50)
+    below.correlation["points-x-bin"] = np.full(50, 100.0)
+    coll = FourierCorrelationDataCollection()
+    coll[0] = below
+    res_below = (
+        FourierCorrelationAnalysis(
+            coll,
+            spacing=0.108,
+            resolution_threshold="fixed",
+            threshold_value=0.143,
+            curve_fit_type="smooth-spline",
+        )
+        .execute(z_correction=1.0)[0]
+        .resolution["resolution"]
+    )
+    assert np.isnan(res_below), (
+        f"Below-threshold curve must return NaN, got {res_below} "
+        "(unbounded fmin previously produced millions-of-µm resolutions)"
+    )
+
+    # Case 2: above-threshold-everywhere curve (perfect prediction).
+    above = FourierCorrelationData()
+    above.correlation["frequency"] = freqs
+    above.correlation["correlation"] = np.full(50, 0.9)
+    above.correlation["points-x-bin"] = np.full(50, 100.0)
+    coll2 = FourierCorrelationDataCollection()
+    coll2[0] = above
+    res_above = (
+        FourierCorrelationAnalysis(
+            coll2,
+            spacing=0.108,
+            resolution_threshold="fixed",
+            threshold_value=0.143,
+            curve_fit_type="smooth-spline",
+        )
+        .execute(z_correction=1.0)[0]
+        .resolution["resolution"]
+    )
+    assert np.isnan(res_above), (
+        f"Above-threshold curve must return NaN, got {res_above}"
+    )
+
+    # Case 3: legitimate crossing — must still produce a finite resolution.
+    legit = FourierCorrelationData()
+    legit.correlation["frequency"] = freqs
+    legit.correlation["correlation"] = 0.9 * np.exp(-3 * freqs) + 0.02
+    legit.correlation["points-x-bin"] = np.full(50, 100.0)
+    coll3 = FourierCorrelationDataCollection()
+    coll3[0] = legit
+    res_legit = (
+        FourierCorrelationAnalysis(
+            coll3,
+            spacing=0.108,
+            resolution_threshold="fixed",
+            threshold_value=0.143,
+            curve_fit_type="smooth-spline",
+        )
+        .execute(z_correction=1.0)[0]
+        .resolution["resolution"]
+    )
+    assert np.isfinite(res_legit) and 0 < res_legit < 100, (
+        f"Legitimate crossing must yield finite reasonable resolution, got {res_legit}"
+    )

--- a/tests/metrics/spectral/test_frc.py
+++ b/tests/metrics/spectral/test_frc.py
@@ -761,11 +761,11 @@ def test_resolution_returns_nan_when_curve_below_threshold() -> None:
     freqs = np.linspace(0.05, 1.0, 50)
 
     # Case 1: below-threshold-everywhere curve (zero-correlation prediction).
+    # Deterministic constant well below 0.143 so the scenario is invariant
+    # across NumPy/RNG versions.
     below = FourierCorrelationData()
     below.correlation["frequency"] = freqs
-    below.correlation["correlation"] = 0.02 + 0.05 * np.random.default_rng(
-        0
-    ).standard_normal(50)
+    below.correlation["correlation"] = np.full(50, 0.02)
     below.correlation["points-x-bin"] = np.full(50, 100.0)
     coll = FourierCorrelationDataCollection()
     coll[0] = below


### PR DESCRIPTION
## Bug

Downstream evaluation surfaced 135 FOVs with FSC resolutions in the **millions of µm** (e.g. XY = 8.3e6 µm for an A549-trained nuclear model on iPSC OOD data). These are all cases where the prediction has essentially zero frequency correlation to GT, so the FSC curve sits below the 0.143 threshold from the lowest measured bin onward.

## Root cause

In `cubic/metrics/spectral/analysis.py`'s `_process_dataset`:

```python
def first_guess(x, y, thr):
    difference = y - thr
    crossings = np.where(difference <= 0)[0]
    if len(crossings) == 0:
        return None  # No threshold crossing found
    return x[crossings[0] - 1] if crossings[0] > 0 else x[0]
```

When `crossings[0] == 0` (curve already below threshold at the first measured bin), the seed `x[0]` is fed to an unbounded `optimize.fmin`. With the `smooth-spline` curve fit, the optimizer can wander far outside the data range (the spline extrapolates) and converge on a tiny or negative `root`. Then `resolution = 2 * spacing / root` blows up — millions of µm, or negative, depending on the sign.

I reproduced the mechanism: on a curve sitting at ~0.02 ± 0.05 across [0.05, 1.0], `fmin` from `fit_start=0.05` converges to `root = −0.0024`, giving `resolution = ∞`.

## Fix

Two-part guard in `_process_dataset`:

1. `first_guess` returns `None` (→ NaN) when `crossings[0] == 0` — the curve starts already below threshold, so there is no legitimate above-to-below crossing.
2. After `fmin`, reject roots that landed outside `[freqs[0], freqs[-1]]`. The unbounded optimizer can still find spurious minima in the extrapolated region even when the curve starts above threshold but never cleanly crosses inside the data range.

Both cases now set `resolution = NaN`, matching the existing "curve never crosses" path. NaN is preferred over capping at Nyquist — it signals "no measurable resolution" rather than implying a meaningful diffraction-limit value.

## Test plan

- [x] Regression test (`test_resolution_returns_nan_when_curve_below_threshold`) covers below-threshold-everywhere → NaN, above-threshold-everywhere → NaN, and a legitimate decay-through-threshold curve → finite reasonable value
- [x] All 33 existing spectral tests pass
- [x] mypy + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure spectral resolution metrics return NaN when FSC/FRC curves never legitimately cross the threshold and harden segmentation utilities against datatype and morphology-API edge cases.

Bug Fixes:
- Return NaN for FSC/FRC resolutions when the curve is always below or above the threshold or when the optimized crossing lies outside the sampled frequency range, avoiding spurious infinite or extreme resolutions.
- Raise a clear TypeError in segmentation label validation when inputs are not integer-typed instead of asserting.
- Make morphological cleanup robust to skimage/cucim API changes for small-object and small-hole removal to avoid runtime errors across versions.

Tests:
- Add regression tests covering below-threshold, above-threshold, and legitimate crossing FSC/FRC curves to validate NaN behavior and finite resolutions.