### PR TITLE
fix(examples): host deconvolution data on Zenodo + pooch auto-download

### DIFF
--- a/examples/data/README.md
+++ b/examples/data/README.md
@@ -1,13 +1,15 @@
 ### Data for running examples
 
-Use the links provided below to download example images and place them in this directory (`examples/data`).
-Resolution estimation notebooks auto-download their datasets on first run using [pooch](https://www.fatiando.org/pooch/).
+Most example notebooks auto-download their datasets on first run using [pooch](https://www.fatiando.org/pooch/) into this directory (`examples/data`). The sources, filenames, and (where helpful) direct download links are listed below.
 
 #### 1. Estimating the number of deconvolution iterations
 
-A single 3D stack of Hoechst-stained astrocyte nuclei acquired with a Yokogawa CQ1 confocal microscope: [download from Google Drive](https://drive.google.com/file/d/1TcCB2TSTLC_iTa0ntHmS8t4wWd4sqFd2/view?usp=sharing).
+Used in `examples/notebooks/deconvolution_iterations_3d.ipynb`. Auto-downloaded on first run using pooch.
 
-Theoretical 3D point spread function (PSF) modeled using the Richards and Wolf algorithm from the PSFGenerator plugin for Fiji: [download from Google Drive](https://drive.google.com/file/d/1AxBVPDXf8EqYtexXlL_WTKAUeYk-ggYc/view?usp=sharing).
+- **`astr_vpa_hoechst.tif`** — Hoechst-stained astrocyte nuclei (3D stack, 16-bit). Yokogawa CQ1 confocal, voxel 0.1625 × 0.1625 × 0.3 µm.
+- **`astr_vpa_hoechst_psf_na095_cropped.tif`** — Theoretical 3D PSF (NA = 0.95) modeled with the Richards & Wolf algorithm from the [PSFGenerator](https://bigwww.epfl.ch/algorithms/psfgenerator/) ImageJ/Fiji plugin. Center-cropped to 30 × 210 × 210 (≥ 99.5% of energy).
+
+Source: [Zenodo record](https://doi.org/10.5281/zenodo.20514102) (DOI [10.5281/zenodo.20514102](https://doi.org/10.5281/zenodo.20514102)).
 
 #### 2. 2D resolution estimation (FRC and DCR)
 

--- a/examples/data/README.md
+++ b/examples/data/README.md
@@ -9,7 +9,7 @@ Used in `examples/notebooks/deconvolution_iterations_3d.ipynb`. Auto-downloaded 
 - **`astr_vpa_hoechst.tif`** — Hoechst-stained astrocyte nuclei (3D stack, 16-bit). Yokogawa CQ1 confocal, voxel 0.1625 × 0.1625 × 0.3 µm.
 - **`astr_vpa_hoechst_psf_na095_cropped.tif`** — Theoretical 3D PSF (NA = 0.95) modeled with the Richards & Wolf algorithm from the [PSFGenerator](https://bigwww.epfl.ch/algorithms/psfgenerator/) ImageJ/Fiji plugin. Center-cropped to 30 × 210 × 210 (≥ 99.5% of energy).
 
-Source: [Zenodo record](https://doi.org/10.5281/zenodo.20514102) (DOI [10.5281/zenodo.20514102](https://doi.org/10.5281/zenodo.20514102)).
+Source: Zenodo, DOI [10.5281/zenodo.20514102](https://doi.org/10.5281/zenodo.20514102).
 
 #### 2. 2D resolution estimation (FRC and DCR)
 

--- a/examples/notebooks/deconvolution_iterations_3d.ipynb
+++ b/examples/notebooks/deconvolution_iterations_3d.ipynb
@@ -21,7 +21,22 @@
     }
    },
    "outputs": [],
-   "source": "import numpy as np\nimport matplotlib.pyplot as plt\nfrom skimage.io import imread\n\nfrom cubic.cuda import CUDAManager, ascupy, asnumpy\nfrom cubic.metrics import psnr, ssim, dcr_resolution, fsc_resolution\nfrom cubic.preprocessing import deconv_iter_num_finder\nfrom cubic.preprocessing.deconvolution import richardson_lucy_iter\n\nUSE_GPU = CUDAManager().num_gpus > 0\nprint(f\"GPU available: {USE_GPU}\")"
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import pooch\n",
+    "import matplotlib.pyplot as plt\n",
+    "from skimage.io import imread\n",
+    "\n",
+    "from cubic.cuda import CUDAManager, ascupy, asnumpy\n",
+    "from cubic.metrics import psnr, ssim, dcr_resolution, fsc_resolution\n",
+    "from cubic.preprocessing import deconv_iter_num_finder\n",
+    "from cubic.preprocessing.deconvolution import richardson_lucy_iter\n",
+    "\n",
+    "USE_GPU = CUDAManager().num_gpus > 0\n",
+    "print(f\"GPU available: {USE_GPU}\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -31,9 +46,43 @@
     "\n",
     "A single 3D stack of Hoechst-stained astrocyte nuclei acquired with a Yokogawa CQ1 confocal microscope.\n",
     "Theoretical 3D point spread function (PSF) was modeled using the Richards and Wolf algorithm from the PSFGenerator plugin for Fiji [1].\n",
-    "The image and the PSF can be [downloaded from Google Drive](../data/README.md).\n",
+    "Both files are auto-downloaded from [Zenodo](https://doi.org/10.5281/zenodo.20514102) on first run.\n",
     "\n",
     "The PSF is center-cropped to 30×210×210 (capturing 99.5% of energy) — RL deconvolution zero-pads it to the image size internally. The image is cropped to a 1024×1024 cell-region patch for faster processing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_DIR = Path(\"../data\")\n",
+    "\n",
+    "\n",
+    "# cubic example dataset: 3D astrocyte nuclei + PSF\n",
+    "# Zenodo record: https://doi.org/10.5281/zenodo.20514102\n",
+    "def fetch_data(filename, url, known_hash):\n",
+    "    \"\"\"Download file to DATA_DIR if not already present.\"\"\"\n",
+    "    return pooch.retrieve(\n",
+    "        url=url,\n",
+    "        known_hash=f\"sha256:{known_hash}\",\n",
+    "        fname=filename,\n",
+    "        path=DATA_DIR,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "fetch_data(\n",
+    "    \"astr_vpa_hoechst.tif\",\n",
+    "    \"https://zenodo.org/api/records/20514102/files/astr_vpa_hoechst.tif/content\",\n",
+    "    \"234533100739f31ea31b78c380bae6cc2ea6b9cebec2c3160eedb89c36967cdc\",\n",
+    ")\n",
+    "\n",
+    "fetch_data(\n",
+    "    \"astr_vpa_hoechst_psf_na095_cropped.tif\",\n",
+    "    \"https://zenodo.org/api/records/20514102/files/astr_vpa_hoechst_psf_na095_cropped.tif/content\",\n",
+    "    \"7a5bfef942a52b8eb683286992058e647937276cd6e5fd43bc32ef6e3134feed\",\n",
+    ");"
    ]
   },
   {
@@ -48,7 +97,28 @@
     }
    },
    "outputs": [],
-   "source": "scale_xy = 0.1625\nscale_z = 0.3\nvoxel_sizes = (scale_z, scale_xy, scale_xy)\n\nimage = imread(\"../data/astr_vpa_hoechst.tif\")\npsf = imread(\"../data/astr_vpa_hoechst_psf_na095_cropped.tif\")\n\n# Crop image to 1024x1024 cell region\ny0, x0 = 1000, 1300  # cell-region anchor\nimage = image[:, y0 : y0 + 1024, x0 : x0 + 1024]\n\nprint(f\"Image shape: {image.shape}\")\nprint(f\"PSF shape:   {psf.shape}\")\n\n# Move to GPU if available\nif USE_GPU:\n    image = ascupy(image)\n    psf = ascupy(psf)\n\nprint(f\"Device: {'GPU' if USE_GPU else 'CPU'}\")"
+   "source": [
+    "scale_xy = 0.1625\n",
+    "scale_z = 0.3\n",
+    "voxel_sizes = (scale_z, scale_xy, scale_xy)\n",
+    "\n",
+    "image = imread(\"../data/astr_vpa_hoechst.tif\")\n",
+    "psf = imread(\"../data/astr_vpa_hoechst_psf_na095_cropped.tif\")\n",
+    "\n",
+    "# Crop image to 1024x1024 cell region\n",
+    "y0, x0 = 1000, 1300  # cell-region anchor\n",
+    "image = image[:, y0 : y0 + 1024, x0 : x0 + 1024]\n",
+    "\n",
+    "print(f\"Image shape: {image.shape}\")\n",
+    "print(f\"PSF shape:   {psf.shape}\")\n",
+    "\n",
+    "# Move to GPU if available\n",
+    "if USE_GPU:\n",
+    "    image = ascupy(image)\n",
+    "    psf = ascupy(psf)\n",
+    "\n",
+    "print(f\"Device: {'GPU' if USE_GPU else 'CPU'}\")"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/examples/notebooks/deconvolution_iterations_3d.ipynb
+++ b/examples/notebooks/deconvolution_iterations_3d.ipynb
@@ -82,7 +82,7 @@
     "    \"astr_vpa_hoechst_psf_na095_cropped.tif\",\n",
     "    \"https://zenodo.org/api/records/20514102/files/astr_vpa_hoechst_psf_na095_cropped.tif/content\",\n",
     "    \"7a5bfef942a52b8eb683286992058e647937276cd6e5fd43bc32ef6e3134feed\",\n",
-    ");"
+    ")"
    ]
   },
   {

--- a/scripts/zenodo_metadata.json
+++ b/scripts/zenodo_metadata.json
@@ -1,0 +1,84 @@
+{
+  "metadata": {
+    "title": "Example data for cubic: 3D astrocyte nuclei and theoretical PSF for deconvolution iteration tracking",
+    "upload_type": "dataset",
+    "description": "<p>Example image data accompanying the <a href=\"https://github.com/alxndrkalinin/cubic\">cubic</a> Python library (CUDA-accelerated 3D bioimage computing).</p><p>Used by the <code>examples/notebooks/deconvolution_iterations_3d.ipynb</code> notebook to demonstrate how PSNR, SSIM, FSC, and DCR can be used to track the progress of Richardson-Lucy 3D deconvolution and inform iteration-count selection.</p><h3>Files</h3><ul><li><strong>astr_vpa_hoechst.tif</strong> &mdash; A single 3D stack of Hoechst-stained astrocyte nuclei (16-bit). Acquired on a Yokogawa CQ1 confocal microscope. Voxel size: 0.1625 &mu;m (xy) &times; 0.3 &mu;m (z).</li><li><strong>astr_vpa_hoechst_psf_na095_cropped.tif</strong> &mdash; Theoretical 3D point spread function (PSF) modeled with the Richards & Wolf algorithm from the <a href=\"https://bigwww.epfl.ch/algorithms/psfgenerator/\">PSFGenerator</a> ImageJ/Fiji plugin (NA = 0.95). Center-cropped to 30&times;210&times;210 (captures &ge; 99.5% of energy); the Richardson-Lucy deconvolution implementation zero-pads it to the image size internally.</li></ul><h3>Citation</h3><p>If you use these data, please cite the cubic paper:</p><blockquote>A. A. Kalinin, A. E. Carpenter, S. Singh, and M. J. O&rsquo;Meara, &ldquo;Cubic: CUDA-Accelerated 3D Bioimage Computing,&rdquo; in <em>2025 IEEE/CVF International Conference on Computer Vision Workshops (ICCVW)</em>, Honolulu, HI, USA, Oct. 2025, pp. 5831&ndash;5840, doi: <a href=\"https://doi.org/10.1109/ICCVW69036.2025.00608\">10.1109/ICCVW69036.2025.00608</a>.</blockquote><p>BibTeX:</p><pre>@inproceedings{kalinin2025cubic,\n  author    = {Kalinin, Alexandr A. and Carpenter, Anne E. and Singh, Shantanu and O'Meara, Matthew J.},\n  title     = {Cubic: {CUDA-Accelerated} {3D} {Bioimage} {Computing}},\n  booktitle = {2025 IEEE/CVF International Conference on Computer Vision Workshops (ICCVW)},\n  year      = {2025},\n  pages     = {5831--5840},\n  address   = {Honolulu, HI, USA},\n  publisher = {IEEE},\n  doi       = {10.1109/ICCVW69036.2025.00608}\n}</pre><p>Open access: <a href=\"https://openaccess.thecvf.com/content/ICCV2025W/BIC/papers/Kalinin_cubic_CUDA-accelerated_3D_BioImage_Computing_ICCVW_2025_paper.pdf\">CVF proceedings PDF</a>. Preprint: <a href=\"https://arxiv.org/abs/2510.14143\">arXiv:2510.14143</a>.</p>",
+    "creators": [
+      {
+        "name": "Kalinin, Alexandr A.",
+        "affiliation": "Broad Institute of MIT and Harvard"
+      },
+      {
+        "name": "Carpenter, Anne E.",
+        "affiliation": "Broad Institute of MIT and Harvard"
+      },
+      {
+        "name": "Singh, Shantanu",
+        "affiliation": "Broad Institute of MIT and Harvard"
+      },
+      {
+        "name": "O'Meara, Matthew J.",
+        "affiliation": "University of Michigan Medical School"
+      }
+    ],
+    "keywords": [
+      "bioimage analysis",
+      "fluorescence microscopy",
+      "confocal microscopy",
+      "Hoechst",
+      "astrocytes",
+      "point spread function",
+      "Richardson-Lucy deconvolution",
+      "image resolution",
+      "FSC",
+      "DCR",
+      "PSNR",
+      "SSIM",
+      "GPU",
+      "CUDA",
+      "cuPy",
+      "cuCIM",
+      "scikit-image",
+      "Python"
+    ],
+    "access_right": "open",
+    "license": "cc-by-4.0",
+    "language": "eng",
+    "related_identifiers": [
+      {
+        "identifier": "10.1109/ICCVW69036.2025.00608",
+        "relation": "isSupplementTo",
+        "resource_type": "publication-conferencepaper",
+        "scheme": "doi"
+      },
+      {
+        "identifier": "https://ieeexplore.ieee.org/document/11375500",
+        "relation": "isSupplementTo",
+        "resource_type": "publication-conferencepaper"
+      },
+      {
+        "identifier": "https://openaccess.thecvf.com/content/ICCV2025W/BIC/papers/Kalinin_cubic_CUDA-accelerated_3D_BioImage_Computing_ICCVW_2025_paper.pdf",
+        "relation": "isSupplementTo",
+        "resource_type": "publication-conferencepaper"
+      },
+      {
+        "identifier": "10.48550/arXiv.2510.14143",
+        "relation": "isPreviousVersionOf",
+        "resource_type": "publication-preprint",
+        "scheme": "doi"
+      },
+      {
+        "identifier": "arXiv:2510.14143",
+        "relation": "isPreviousVersionOf",
+        "resource_type": "publication-preprint"
+      },
+      {
+        "identifier": "https://github.com/alxndrkalinin/cubic",
+        "relation": "isSupplementTo",
+        "resource_type": "software"
+      }
+    ],
+    "version": "1.0.0",
+    "notes": "Files are reproducible with the cubic example notebook examples/notebooks/deconvolution_iterations_3d.ipynb. sha256: astr_vpa_hoechst.tif=234533100739f31ea31b78c380bae6cc2ea6b9cebec2c3160eedb89c36967cdc; astr_vpa_hoechst_psf_na095_cropped.tif=7a5bfef942a52b8eb683286992058e647937276cd6e5fd43bc32ef6e3134feed."
+  }
+}

--- a/scripts/zenodo_upload.py
+++ b/scripts/zenodo_upload.py
@@ -1,0 +1,193 @@
+"""Create a Zenodo deposition and upload cubic's deconvolution example data.
+
+Usage
+-----
+1. Get a personal access token (with ``deposit:write`` and
+   ``deposit:actions`` scopes) from https://zenodo.org/account/settings/applications/
+   (or https://sandbox.zenodo.org/account/settings/applications/ for testing).
+2. Export it: ``export ZENODO_TOKEN=<token>``
+3. Run from the repo root:
+
+   .. code-block:: bash
+
+       # sandbox dry-run (recommended first):
+       python scripts/zenodo_upload.py --sandbox
+
+       # real upload:
+       python scripts/zenodo_upload.py
+
+       # by default, the deposition is left as a DRAFT for the user to
+       # inspect and publish from the Zenodo UI. Pass --publish to
+       # publish immediately (irreversible; metadata becomes locked
+       # except via a versioned update).
+       python scripts/zenodo_upload.py --publish
+
+The script:
+- POSTs a new deposition (empty),
+- attaches metadata loaded from ``scripts/zenodo_metadata.json``,
+- streams each file in ``FILES_TO_UPLOAD`` to the deposition's bucket,
+- verifies returned checksums against locally computed sha256/md5,
+- prints the draft link (and final DOI if ``--publish`` is set).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import json
+import hashlib
+import argparse
+from pathlib import Path
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+METADATA_PATH = REPO_ROOT / "scripts" / "zenodo_metadata.json"
+
+FILES_TO_UPLOAD: list[tuple[Path, str]] = [
+    (REPO_ROOT / "examples/data/astr_vpa_hoechst.tif", "astr_vpa_hoechst.tif"),
+    (
+        REPO_ROOT / "examples/data/astr_vpa_hoechst_psf_na095_cropped.tif",
+        "astr_vpa_hoechst_psf_na095_cropped.tif",
+    ),
+]
+
+EXPECTED_SHA256: dict[str, str] = {
+    "astr_vpa_hoechst.tif": "234533100739f31ea31b78c380bae6cc2ea6b9cebec2c3160eedb89c36967cdc",
+    "astr_vpa_hoechst_psf_na095_cropped.tif": "7a5bfef942a52b8eb683286992058e647937276cd6e5fd43bc32ef6e3134feed",
+}
+
+
+def hash_file(path: Path, algos: tuple[str, ...] = ("sha256", "md5")) -> dict[str, str]:
+    """Stream ``path`` and return one hex digest per algorithm in ``algos``."""
+    hashers = {a: hashlib.new(a) for a in algos}
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(8 * 1024 * 1024), b""):
+            for h in hashers.values():
+                h.update(chunk)
+    return {a: hashers[a].hexdigest() for a in algos}
+
+
+def main() -> int:
+    """Upload ``FILES_TO_UPLOAD`` to a new Zenodo deposition with the configured metadata."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sandbox",
+        action="store_true",
+        help="Use sandbox.zenodo.org instead of zenodo.org.",
+    )
+    parser.add_argument(
+        "--publish",
+        action="store_true",
+        help="Publish the deposition after upload (irreversible).",
+    )
+    parser.add_argument(
+        "--metadata",
+        type=Path,
+        default=METADATA_PATH,
+        help=f"Path to deposition metadata JSON (default: {METADATA_PATH}).",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("ZENODO_TOKEN")
+    if not token:
+        print("ERROR: ZENODO_TOKEN env var is not set.", file=sys.stderr)
+        return 2
+
+    base = "https://sandbox.zenodo.org" if args.sandbox else "https://zenodo.org"
+    api = f"{base}/api"
+    params = {"access_token": token}
+
+    metadata = json.loads(args.metadata.read_text())
+    print(f"Loaded metadata from {args.metadata}")
+    print(f"  title: {metadata['metadata']['title']}")
+    print(f"  creators: {len(metadata['metadata']['creators'])}")
+    print(f"  license: {metadata['metadata']['license']}")
+
+    for p, _ in FILES_TO_UPLOAD:
+        if not p.is_file():
+            print(f"ERROR: missing file {p}", file=sys.stderr)
+            return 2
+
+    print(f"\nUsing Zenodo endpoint: {base}")
+    print("Creating empty deposition...")
+    r = requests.post(f"{api}/deposit/depositions", params=params, json={}, timeout=30)
+    r.raise_for_status()
+    deposition = r.json()
+    dep_id = deposition["id"]
+    bucket_url = deposition["links"]["bucket"]
+    html_url = deposition["links"]["html"]
+    print(f"  deposition id: {dep_id}")
+    print(f"  draft URL:     {html_url}")
+    print(f"  bucket URL:    {bucket_url}")
+
+    print("\nAttaching metadata...")
+    r = requests.put(
+        f"{api}/deposit/depositions/{dep_id}",
+        params=params,
+        json=metadata,
+        headers={"Content-Type": "application/json"},
+        timeout=30,
+    )
+    r.raise_for_status()
+    print("  ok.")
+
+    for path, remote_name in FILES_TO_UPLOAD:
+        size_mb = path.stat().st_size / 1e6
+        print(f"\nUploading {remote_name} ({size_mb:.1f} MB)...")
+        hashes = hash_file(path)
+        if (
+            remote_name in EXPECTED_SHA256
+            and hashes["sha256"] != EXPECTED_SHA256[remote_name]
+        ):
+            print(
+                f"ERROR: local sha256 for {remote_name} does not match the "
+                f"committed expected value. Local={hashes['sha256']}, "
+                f"expected={EXPECTED_SHA256[remote_name]}.",
+                file=sys.stderr,
+            )
+            return 3
+        with path.open("rb") as fh:
+            r = requests.put(
+                f"{bucket_url}/{remote_name}",
+                params=params,
+                data=fh,
+                timeout=None,
+            )
+        r.raise_for_status()
+        info = r.json()
+        zenodo_md5 = info.get("checksum", "").removeprefix("md5:")
+        if zenodo_md5 != hashes["md5"]:
+            print(
+                f"ERROR: md5 mismatch for {remote_name}. "
+                f"local={hashes['md5']} zenodo={zenodo_md5}.",
+                file=sys.stderr,
+            )
+            return 4
+        print(f"  ok. sha256={hashes['sha256']} md5={hashes['md5']}")
+
+    if args.publish:
+        print("\nPublishing deposition (irreversible)...")
+        r = requests.post(
+            f"{api}/deposit/depositions/{dep_id}/actions/publish",
+            params=params,
+            timeout=60,
+        )
+        r.raise_for_status()
+        published = r.json()
+        doi = published.get("doi") or published.get("metadata", {}).get("doi")
+        concept_doi = published.get("conceptdoi")
+        print("\nPublished.")
+        print(f"  version DOI: {doi}")
+        print(f"  concept DOI: {concept_doi}")
+        print(f"  record URL:  {published['links'].get('record_html')}")
+    else:
+        print("\nDraft created. Inspect at:")
+        print(f"  {html_url}")
+        print("Rerun with --publish to publish, or click 'Publish' in the Zenodo UI.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zenodo_upload.py
+++ b/scripts/zenodo_upload.py
@@ -1,4 +1,9 @@
-"""Create a Zenodo deposition and upload cubic's deconvolution example data.
+"""Create a Zenodo deposition and upload a cubic example dataset.
+
+The current ``FILES_TO_UPLOAD`` / ``EXPECTED_SHA256`` / metadata JSON are
+set up for the deconvolution example data. To reuse for another dataset,
+point ``FILES_TO_UPLOAD`` and ``EXPECTED_SHA256`` at the new files and
+edit ``scripts/zenodo_metadata.json``.
 
 Usage
 -----

--- a/scripts/zenodo_upload.py
+++ b/scripts/zenodo_upload.py
@@ -39,7 +39,14 @@ import hashlib
 import argparse
 from pathlib import Path
 
-import requests
+try:
+    import requests
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit(
+        "zenodo_upload.py requires the `requests` package, which is not a "
+        "cubic runtime dependency. Install it into your environment first: "
+        "`pip install requests` (or `uv pip install requests`)."
+    ) from exc
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 METADATA_PATH = REPO_ROOT / "scripts" / "zenodo_metadata.json"

--- a/scripts/zenodo_upload.py
+++ b/scripts/zenodo_upload.py
@@ -155,11 +155,15 @@ def main() -> int:
             )
             return 3
         with path.open("rb") as fh:
+            # (connect, read) — a 30-minute read timeout tolerates slow
+            # uploads of large depositions (Zenodo's bucket API streams
+            # chunked) but still surfaces stalled connections instead of
+            # hanging the script indefinitely.
             r = requests.put(
                 f"{bucket_url}/{remote_name}",
                 params=params,
                 data=fh,
-                timeout=None,
+                timeout=(10, 1800),
             )
         r.raise_for_status()
         info = r.json()


### PR DESCRIPTION
Closes #47.

## Problem
Both Google Drive links in `examples/data/README.md` (deconvolution section) had stopped resolving, leaving `examples/notebooks/deconvolution_iterations_3d.ipynb` with no way to bootstrap its inputs (a 3D Hoechst-stained astrocyte stack and a theoretical PSF).

## Fix
Republished both files on Zenodo under CC-BY-4.0 with the proper IEEE archived citation:

- **Version DOI**: [10.5281/zenodo.20514102](https://doi.org/10.5281/zenodo.20514102)
- **Concept DOI**: [10.5281/zenodo.20514101](https://doi.org/10.5281/zenodo.20514101)
- **Record**: https://zenodo.org/records/20514102
- Related identifiers: cubic ICCVW paper DOI `10.1109/ICCVW69036.2025.00608`, IEEE Xplore URL, CVF open-access PDF, arXiv preprint, GitHub repo.

`deconvolution_iterations_3d.ipynb` now pulls both files via `pooch` with `sha256` verification on first run, matching the pattern used by the other resolution / segmentation example notebooks. The `examples/data/README.md` entry is rewritten with filenames, acquisition / modeling details, and the Zenodo DOI.

## Tooling
Adds `scripts/zenodo_upload.py` + `scripts/zenodo_metadata.json` — the script used to create the deposition. Reusable for future cubic example datasets (point `FILES_TO_UPLOAD` and the metadata JSON at the new files and rerun; deposition stays as a draft unless `--publish` is passed).

## Test plan
- [ ] Open `examples/notebooks/deconvolution_iterations_3d.ipynb` from a fresh checkout (no local `examples/data/astr_vpa_hoechst*.tif`), run cells 1-4 — pooch should download both files into `examples/data/` and the load cell should succeed.
- [ ] Confirm sha256 hashes match the values committed in the new fetch cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch the deconvolution example to auto-download its input data from Zenodo and add tooling to manage the Zenodo deposition.

New Features:
- Enable automatic download and integrity checking of the 3D deconvolution example dataset from Zenodo using pooch.
- Add a reusable script and metadata file for creating and publishing Zenodo depositions of example datasets.

Enhancements:
- Update the deconvolution example notebook to use the new auto-downloaded data files rather than assuming they are present locally.

Documentation:
- Revise the example data README to document the new Zenodo-hosted deconvolution dataset, including filenames and acquisition details.