### PR TITLE
feat(feature): GLCM texture features + regionprops extra_properties

### DIFF
--- a/cubic/__init__.py
+++ b/cubic/__init__.py
@@ -1,3 +1,3 @@
 """Morphomeric analysis of 3D cell images."""
 
-__version__ = "0.7.0a11"
+__version__ = "0.7.0a12"

--- a/cubic/feature/__init__.py
+++ b/cubic/feature/__init__.py
@@ -1,8 +1,10 @@
 """Expose feature extraction functions."""
 
 from .voxel import regionprops, regionprops_table
+from .texture import glcm_features
 
 __all__ = [
     "regionprops",
+    "glcm_features",
     "regionprops_table",
 ]

--- a/cubic/feature/texture.py
+++ b/cubic/feature/texture.py
@@ -24,17 +24,6 @@ import numpy as np
 
 from ..cuda import asnumpy
 
-# Haralick properties emitted by :func:`glcm_features`, in a fixed order.
-_PROPS: tuple[str, ...] = (
-    "ASM",
-    "energy",
-    "entropy",
-    "contrast",
-    "correlation",
-    "homogeneity",
-    "dissimilarity",
-)
-
 
 def _unit_offsets(ndim: int) -> list[tuple[int, ...]]:
     """Return the unique half-space neighbor offsets for ``ndim`` dimensions.
@@ -132,18 +121,23 @@ def _direction_matrix(
     return counts
 
 
-def _haralick_props(glcm: np.ndarray, levels: int) -> dict[str, float]:
+def _haralick_props(
+    glcm: np.ndarray,
+    i: np.ndarray,
+    j: np.ndarray,
+    diff_sq: np.ndarray,
+    abs_diff: np.ndarray,
+) -> dict[str, float]:
     """Compute Haralick properties of a normalized GLCM (host NumPy array).
+
+    ``i``/``j`` are the level-index ramps and ``diff_sq``/``abs_diff`` the
+    squared and absolute level differences; they are direction-independent,
+    so the caller computes them once and reuses them across directions.
 
     Reproduces ``skimage.feature.graycoprops`` exactly for ``contrast``,
     ``dissimilarity``, ``homogeneity``, ``ASM``, ``energy``, ``correlation``
     (including the near-zero-std guard), plus ``entropy`` (natural log).
     """
-    levels_idx = np.arange(levels)
-    i = levels_idx[:, None]
-    j = levels_idx[None, :]
-    diff = i - j
-
     asm = float(np.sum(glcm**2))
     nonzero = glcm > 0
     entropy = float(-np.sum(glcm[nonzero] * np.log(glcm[nonzero])))
@@ -164,10 +158,10 @@ def _haralick_props(glcm: np.ndarray, levels: int) -> dict[str, float]:
         "ASM": asm,
         "energy": float(np.sqrt(asm)),
         "entropy": entropy,
-        "contrast": float(np.sum(glcm * diff**2)),
+        "contrast": float(np.sum(glcm * diff_sq)),
         "correlation": correlation,
-        "homogeneity": float(np.sum(glcm / (1.0 + diff**2))),
-        "dissimilarity": float(np.sum(glcm * np.abs(diff))),
+        "homogeneity": float(np.sum(glcm / (1.0 + diff_sq))),
+        "dissimilarity": float(np.sum(glcm * abs_diff)),
     }
 
 
@@ -256,12 +250,24 @@ def glcm_features(
         for unit in _unit_offsets(image.ndim)
     ]
 
-    totals = {prop: 0.0 for prop in _PROPS}
-    for off in offsets:
-        glcm = _direction_matrix(quant, off, levels, mask, symmetric, normed)
-        props = _haralick_props(glcm, levels)
-        for prop in _PROPS:
-            totals[prop] += props[prop]
+    # Direction-independent level-index ramps, computed once and reused for
+    # every direction's property reduction.
+    levels_idx = np.arange(levels)
+    i = levels_idx[:, None]
+    j = levels_idx[None, :]
+    diff = i - j
+    diff_sq = diff * diff
+    abs_diff = np.abs(diff)
 
-    n = len(offsets)
-    return {prop: totals[prop] / n for prop in _PROPS}
+    per_direction = [
+        _haralick_props(
+            _direction_matrix(quant, off, levels, mask, symmetric, normed),
+            i,
+            j,
+            diff_sq,
+            abs_diff,
+        )
+        for off in offsets
+    ]
+    n = len(per_direction)
+    return {prop: sum(d[prop] for d in per_direction) / n for prop in per_direction[0]}

--- a/cubic/feature/texture.py
+++ b/cubic/feature/texture.py
@@ -108,8 +108,18 @@ def _direction_matrix(
         center = center[valid]
         neighbor = neighbor[valid]
     index = (center * levels + neighbor).ravel()
-    counts = np.bincount(index, minlength=levels * levels).reshape(levels, levels)
-    counts = asnumpy(counts).astype(np.float64)
+    if index.size == 0:
+        # No valid pairs for this direction: an empty overlap (e.g. a
+        # single-row image's vertical offsets) or a fully masked-out
+        # direction. ``cupy.bincount`` raises on empty input (it reduces
+        # ``x.max()`` to size the output, which has no identity), so build
+        # the zero matrix directly. The resulting all-zero GLCM yields the
+        # same properties skimage gives for an empty co-occurrence matrix
+        # (contrast/entropy 0, correlation 1.0 via the std guard).
+        counts = np.zeros((levels, levels), dtype=np.float64)
+    else:
+        counts = np.bincount(index, minlength=levels * levels).reshape(levels, levels)
+        counts = asnumpy(counts).astype(np.float64)
     if symmetric:
         counts = counts + counts.T
     if normed:

--- a/cubic/feature/texture.py
+++ b/cubic/feature/texture.py
@@ -220,8 +220,9 @@ def glcm_features(
     ------
     ValueError
         If ``image`` is not 2D or 3D, ``mask`` shape mismatches, ``levels``
-        is below 2, or the masked region is empty when ``value_range`` is
-        derived from the image.
+        is below 2, ``distances`` is empty or contains a non-positive value,
+        or the masked region is empty when ``value_range`` is derived from
+        the image.
     """
     if image.ndim not in (2, 3):
         raise ValueError(
@@ -233,6 +234,10 @@ def glcm_features(
         )
     if levels < 2:
         raise ValueError(f"levels must be >= 2; got {levels}")
+    if not distances or any(distance < 1 for distance in distances):
+        raise ValueError(
+            f"distances must be a non-empty sequence of positive integers; got {distances}"
+        )
 
     if value_range is None:
         region = image[mask] if mask is not None else image

--- a/cubic/feature/texture.py
+++ b/cubic/feature/texture.py
@@ -1,0 +1,254 @@
+"""Device-agnostic gray-level co-occurrence matrix (GLCM) texture features.
+
+cuCIM has no ``graycomatrix`` (rapidsai/cucim#530), and scikit-image's is
+2D-only (``check_nD(image, 2)``). This module provides Haralick texture
+features for both 2D ``(H, W)`` and 3D ``(D, H, W)`` images that run on
+NumPy (CPU) or CuPy (GPU) arrays through duck typing.
+
+The co-occurrence matrix is accumulated with ``np.bincount`` (which works on
+both NumPy and CuPy arrays), and the Haralick properties are computed with
+closed-form reductions that reproduce ``skimage.feature.graycoprops``
+exactly, including its ``correlation`` guard (set to ``1.0`` when a marginal
+standard deviation is below ``1e-15`` rather than yielding NaN).
+
+Quantization is performed over a per-image ``value_range`` by default, which
+makes the features scale-invariant: ``glcm_features(x) == glcm_features(2x + 5)``
+because an affine intensity change leaves the relative bin assignments
+unchanged. Pass an explicit ``value_range`` to quantize several regions over a
+shared set of levels (e.g. cells of one already-normalized image).
+"""
+
+import itertools
+
+import numpy as np
+
+from ..cuda import asnumpy
+
+# Haralick properties emitted by :func:`glcm_features`, in a fixed order.
+_PROPS: tuple[str, ...] = (
+    "ASM",
+    "energy",
+    "entropy",
+    "contrast",
+    "correlation",
+    "homogeneity",
+    "dissimilarity",
+)
+
+
+def _unit_offsets(ndim: int) -> list[tuple[int, ...]]:
+    """Return the unique half-space neighbor offsets for ``ndim`` dimensions.
+
+    Each offset and its negation produce the same symmetric co-occurrence
+    matrix, so only one representative per antipodal pair is kept: the one
+    whose first non-zero coordinate is positive. This yields the 4 unique
+    2D directions (skimage angles 0/45/90/135 deg) and the 13 unique 3D
+    directions of the 26-neighborhood.
+    """
+    offsets = []
+    for off in itertools.product((-1, 0, 1), repeat=ndim):
+        first_nonzero = next((o for o in off if o != 0), 0)
+        if first_nonzero > 0:
+            offsets.append(off)
+    return offsets
+
+
+def _slices_for_offset(
+    off: tuple[int, ...], shape: tuple[int, ...]
+) -> tuple[tuple[slice, ...], tuple[slice, ...]]:
+    """Return (center, neighbor) slice tuples for the overlapping pair region.
+
+    Matches scikit-image's GLCM valid-region convention: for a positive
+    offset the center is ``[0:n-o]`` and the neighbor ``[o:n]``; for a
+    negative offset the roles are mirrored.
+    """
+    center, neighbor = [], []
+    for o, n in zip(off, shape):
+        if o >= 0:
+            center.append(slice(0, n - o))
+            neighbor.append(slice(o, n))
+        else:
+            center.append(slice(-o, n))
+            neighbor.append(slice(0, n + o))
+    return tuple(center), tuple(neighbor)
+
+
+def _quantize(image: np.ndarray, levels: int, lo: float, hi: float) -> np.ndarray:
+    """Quantize ``image`` into ``[0, levels - 1]`` over ``[lo, hi]``.
+
+    Stays on the input array's device (NumPy or CuPy). A constant range
+    (``hi <= lo``) maps every voxel to bin 0.
+    """
+    span = hi - lo
+    if span <= 0:
+        return (image * 0).astype(np.int64)
+    scaled = (image - lo) / span * levels
+    return np.clip(np.floor(scaled), 0, levels - 1).astype(np.int64)
+
+
+def _direction_matrix(
+    quant: np.ndarray,
+    off: tuple[int, ...],
+    levels: int,
+    mask: np.ndarray | None,
+    symmetric: bool,
+    normed: bool,
+) -> np.ndarray:
+    """Accumulate the GLCM for a single offset and return it as a NumPy array.
+
+    Pairs are counted with ``np.bincount`` on the device, then the small
+    ``(levels, levels)`` matrix is moved to the host for the property
+    reductions.
+    """
+    center_sl, neighbor_sl = _slices_for_offset(off, quant.shape)
+    center = quant[center_sl]
+    neighbor = quant[neighbor_sl]
+    if mask is not None:
+        valid = mask[center_sl] & mask[neighbor_sl]
+        center = center[valid]
+        neighbor = neighbor[valid]
+    index = (center * levels + neighbor).ravel()
+    counts = np.bincount(index, minlength=levels * levels).reshape(levels, levels)
+    counts = asnumpy(counts).astype(np.float64)
+    if symmetric:
+        counts = counts + counts.T
+    if normed:
+        total = counts.sum()
+        if total > 0:
+            counts = counts / total
+    return counts
+
+
+def _haralick_props(glcm: np.ndarray, levels: int) -> dict[str, float]:
+    """Compute Haralick properties of a normalized GLCM (host NumPy array).
+
+    Reproduces ``skimage.feature.graycoprops`` exactly for ``contrast``,
+    ``dissimilarity``, ``homogeneity``, ``ASM``, ``energy``, ``correlation``
+    (including the near-zero-std guard), plus ``entropy`` (natural log).
+    """
+    levels_idx = np.arange(levels)
+    i = levels_idx[:, None]
+    j = levels_idx[None, :]
+    diff = i - j
+
+    asm = float(np.sum(glcm**2))
+    nonzero = glcm > 0
+    entropy = float(-np.sum(glcm[nonzero] * np.log(glcm[nonzero])))
+
+    mean_i = float(np.sum(i * glcm))
+    mean_j = float(np.sum(j * glcm))
+    diff_i = i - mean_i
+    diff_j = j - mean_j
+    std_i = float(np.sqrt(np.sum(glcm * diff_i**2)))
+    std_j = float(np.sqrt(np.sum(glcm * diff_j**2)))
+    cov = float(np.sum(glcm * diff_i * diff_j))
+    if std_i < 1e-15 or std_j < 1e-15:
+        correlation = 1.0
+    else:
+        correlation = cov / (std_i * std_j)
+
+    return {
+        "ASM": asm,
+        "energy": float(np.sqrt(asm)),
+        "entropy": entropy,
+        "contrast": float(np.sum(glcm * diff**2)),
+        "correlation": correlation,
+        "homogeneity": float(np.sum(glcm / (1.0 + diff**2))),
+        "dissimilarity": float(np.sum(glcm * np.abs(diff))),
+    }
+
+
+def glcm_features(
+    image: np.ndarray,
+    *,
+    mask: np.ndarray | None = None,
+    levels: int = 32,
+    distances: tuple[int, ...] = (1,),
+    symmetric: bool = True,
+    normed: bool = True,
+    value_range: tuple[float, float] | None = None,
+) -> dict[str, float]:
+    """Extract Haralick GLCM texture features, device-agnostic for 2D and 3D.
+
+    The image is quantized into ``levels`` gray levels over ``value_range``,
+    a co-occurrence matrix is accumulated for every half-space direction
+    (4 in 2D, 13 in 3D) and distance, the Haralick properties are computed
+    per direction, and the results are averaged over all directions for
+    rotation invariance.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        2D ``(H, W)`` or 3D ``(D, H, W)`` image (NumPy or CuPy array).
+    mask : np.ndarray, optional
+        Boolean foreground mask of the same shape as ``image``. When given,
+        a pair contributes to the GLCM only if both voxels are inside the
+        mask, so background-to-foreground pairs are excluded.
+    levels : int, default 32
+        Number of gray levels to quantize into. Must be >= 2.
+    distances : tuple of int, default (1,)
+        Pixel-pair offset distances. Each unit direction is scaled by the
+        distance (integer offsets); for ``distance == 1`` the directions
+        match scikit-image's GLCM offsets exactly.
+    symmetric : bool, default True
+        If True, accumulate ``(i, j)`` and ``(j, i)`` together so each
+        direction's matrix is symmetric.
+    normed : bool, default True
+        If True, normalize each direction's matrix to sum to 1. Keep True
+        (the default) for properties that match ``graycoprops``.
+    value_range : tuple of float, optional
+        ``(low, high)`` intensity range used for quantization. Defaults to
+        the per-image (or per-mask) ``(min, max)``, which makes the features
+        scale-invariant. Pass a shared range to quantize several regions
+        over the same levels.
+
+    Returns
+    -------
+    dict of str to float
+        ``contrast``, ``dissimilarity``, ``homogeneity``, ``ASM``,
+        ``energy``, ``correlation`` and ``entropy``, each averaged over all
+        directions.
+
+    Raises
+    ------
+    ValueError
+        If ``image`` is not 2D or 3D, ``mask`` shape mismatches, ``levels``
+        is below 2, or the masked region is empty when ``value_range`` is
+        derived from the image.
+    """
+    if image.ndim not in (2, 3):
+        raise ValueError(
+            f"Only 2D (H, W) or 3D (D, H, W) images are supported; got ndim={image.ndim}"
+        )
+    if mask is not None and mask.shape != image.shape:
+        raise ValueError(
+            f"mask shape {mask.shape} must match image shape {image.shape}"
+        )
+    if levels < 2:
+        raise ValueError(f"levels must be >= 2; got {levels}")
+
+    if value_range is None:
+        region = image[mask] if mask is not None else image
+        if region.size == 0:
+            raise ValueError("Cannot derive value_range from an empty masked region.")
+        lo = float(region.min())
+        hi = float(region.max())
+    else:
+        lo, hi = float(value_range[0]), float(value_range[1])
+
+    quant = _quantize(image, levels, lo, hi)
+    offsets = [
+        tuple(distance * axis for axis in unit)
+        for distance in distances
+        for unit in _unit_offsets(image.ndim)
+    ]
+
+    totals = {prop: 0.0 for prop in _PROPS}
+    for off in offsets:
+        glcm = _direction_matrix(quant, off, levels, mask, symmetric, normed)
+        props = _haralick_props(glcm, levels)
+        for prop in _PROPS:
+            totals[prop] += props[prop]
+
+    n = len(offsets)
+    return {prop: totals[prop] / n for prop in _PROPS}

--- a/cubic/feature/texture.py
+++ b/cubic/feature/texture.py
@@ -118,8 +118,11 @@ def _direction_matrix(
         # (contrast/entropy 0, correlation 1.0 via the std guard).
         counts = np.zeros((levels, levels), dtype=np.float64)
     else:
-        counts = np.bincount(index, minlength=levels * levels).reshape(levels, levels)
-        counts = asnumpy(counts).astype(np.float64)
+        counts = (
+            asnumpy(np.bincount(index, minlength=levels * levels))
+            .reshape(levels, levels)
+            .astype(np.float64)
+        )
     if symmetric:
         counts = counts + counts.T
     if normed:

--- a/cubic/feature/voxel.py
+++ b/cubic/feature/voxel.py
@@ -29,7 +29,11 @@ def regionprops_table(
 ) -> dict[str, np.ndarray]:
     """Extract region-based morphological features and return in pandas-compatible format."""
     if properties is not None:
-        properties = list(set(properties + ["label"]))
+        # Order-preserving dedup. A bare ``set()`` iterates in an order that
+        # depends on the interpreter hash seed, which differs per spawned
+        # process worker, so it would scramble the output column order across
+        # multiprocessing workers and misalign the pooled feature matrix.
+        properties = list(dict.fromkeys([*properties, "label"]))
     else:
         properties = []
     # cucim requires spacing as tuple for kernel memoization

--- a/cubic/feature/voxel.py
+++ b/cubic/feature/voxel.py
@@ -14,11 +14,25 @@ def regionprops(
     label_image: npt.ArrayLike,
     intensity_image: npt.ArrayLike | None = None,
     spacing: list[float] | None = None,
+    extra_properties: tuple | None = None,
 ) -> list:
-    """Extract region-based morphological features."""
+    """Extract region-based morphological features.
+
+    Parameters
+    ----------
+    extra_properties : tuple of callable, optional
+        User-defined property functions ``func(regionmask, intensity)``
+        forwarded to ``measure.regionprops`` (both skimage and cucim
+        accept them).
+    """
     # cucim requires spacing as tuple for kernel memoization
     spacing_arg = tuple(spacing) if spacing is not None else None
-    return measure.regionprops(label_image, intensity_image, spacing=spacing_arg)
+    return measure.regionprops(
+        label_image,
+        intensity_image,
+        spacing=spacing_arg,
+        extra_properties=extra_properties,
+    )
 
 
 def regionprops_table(
@@ -26,8 +40,17 @@ def regionprops_table(
     intensity_image: npt.ArrayLike | None = None,
     properties: list[str] | None = None,
     spacing: list[float] | None = None,
+    extra_properties: tuple | None = None,
 ) -> dict[str, np.ndarray]:
-    """Extract region-based morphological features and return in pandas-compatible format."""
+    """Extract region-based morphological features and return in pandas-compatible format.
+
+    Parameters
+    ----------
+    extra_properties : tuple of callable, optional
+        User-defined property functions ``func(regionmask, intensity)``
+        forwarded to ``measure.regionprops_table`` (both skimage and
+        cucim accept them).
+    """
     if properties is not None:
         # Order-preserving dedup. A bare ``set()`` iterates in an order that
         # depends on the interpreter hash seed, which differs per spawned
@@ -39,7 +62,11 @@ def regionprops_table(
     # cucim requires spacing as tuple for kernel memoization
     spacing_arg = tuple(spacing) if spacing is not None else None
     return measure.regionprops_table(
-        label_image, intensity_image, properties=properties, spacing=spacing_arg
+        label_image,
+        intensity_image,
+        properties=properties,
+        spacing=spacing_arg,
+        extra_properties=extra_properties,
     )
 
 

--- a/tests/feature/test_texture.py
+++ b/tests/feature/test_texture.py
@@ -133,6 +133,10 @@ def test_glcm_rejects_bad_input() -> None:
         glcm_features(img2d, mask=np.zeros((4, 4), dtype=bool))
     with pytest.raises(ValueError, match="levels"):
         glcm_features(img2d, levels=1)
+    with pytest.raises(ValueError, match="distances"):
+        glcm_features(img2d, distances=())
+    with pytest.raises(ValueError, match="distances"):
+        glcm_features(img2d, distances=(0,))
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])

--- a/tests/feature/test_texture.py
+++ b/tests/feature/test_texture.py
@@ -1,0 +1,144 @@
+"""Tests for the GLCM texture feature module."""
+
+import numpy as np
+import pytest
+from skimage.feature import graycoprops, graycomatrix
+
+from cubic.cuda import ascupy
+from cubic.feature import glcm_features
+from cubic.feature.texture import _PROPS, _unit_offsets
+
+_ANGLES = [0, np.pi / 4, np.pi / 2, 3 * np.pi / 4]
+
+
+def _skimage_reference(image: np.ndarray, levels: int) -> dict[str, float]:
+    """Direction-averaged graycoprops for an already-quantized integer image."""
+    glcm = graycomatrix(
+        image, distances=[1], angles=_ANGLES, levels=levels, symmetric=True, normed=True
+    )
+    ref = {
+        prop: float(graycoprops(glcm, prop).mean())
+        for prop in (
+            "contrast",
+            "dissimilarity",
+            "homogeneity",
+            "ASM",
+            "energy",
+            "correlation",
+        )
+    }
+    # Hand-computed entropy (natural log), averaged over the four angles.
+    entropies = []
+    for a in range(glcm.shape[3]):
+        plane = glcm[:, :, 0, a]
+        nonzero = plane > 0
+        entropies.append(float(-np.sum(plane[nonzero] * np.log(plane[nonzero]))))
+    ref["entropy"] = float(np.mean(entropies))
+    return ref
+
+
+def test_glcm_2d_matches_graycoprops() -> None:
+    """All seven properties match skimage's graycoprops on a 2D image."""
+    rng = np.random.default_rng(0)
+    levels = 8
+    quant = rng.integers(0, levels, size=(20, 25)).astype(np.uint8)
+
+    # value_range=(0, levels) makes quantization the identity for an integer
+    # image already in [0, levels - 1], so both paths see the same array.
+    feats = glcm_features(
+        quant.astype(np.float64), levels=levels, value_range=(0.0, levels)
+    )
+    ref = _skimage_reference(quant, levels)
+
+    assert set(feats) == set(ref)
+    for prop in ref:
+        assert abs(feats[prop] - ref[prop]) < 1e-9, prop
+
+
+def test_unit_offsets_counts_and_half_space() -> None:
+    """2D has 4 directions, 3D has 13, with no antipodal duplicates."""
+    assert len(_unit_offsets(2)) == 4
+    assert len(_unit_offsets(3)) == 13
+    for ndim in (2, 3):
+        offsets = set(_unit_offsets(ndim))
+        for off in offsets:
+            first_nonzero = next(o for o in off if o != 0)
+            assert first_nonzero > 0
+            assert tuple(-o for o in off) not in offsets
+
+
+def test_glcm_3d_runs_and_is_finite() -> None:
+    """3D images produce all properties as finite scalars."""
+    rng = np.random.default_rng(2)
+    vol = rng.random((12, 16, 18)).astype(np.float32)
+    feats = glcm_features(vol, levels=16)
+    assert set(feats) == set(_PROPS)
+    for value in feats.values():
+        assert np.isfinite(value)
+
+
+@pytest.mark.parametrize("scale,shift", [(2.0, 5.0), (0.5, -3.0)])
+def test_glcm_scale_invariance(scale: float, shift: float) -> None:
+    """Affine intensity changes leave features unchanged with per-image range."""
+    rng = np.random.default_rng(3)
+    img = rng.random((30, 40)).astype(np.float64)
+    base = glcm_features(img, levels=16)
+    scaled = glcm_features(img * scale + shift, levels=16)
+    for prop in base:
+        assert abs(base[prop] - scaled[prop]) < 1e-9, prop
+
+
+def test_glcm_mask_excludes_background_pairs() -> None:
+    """Masked-out voxels do not contribute co-occurrence pairs."""
+    rng = np.random.default_rng(4)
+    levels = 8
+    img = rng.random((24, 24)).astype(np.float64)
+    mask = np.zeros(img.shape, dtype=bool)
+    mask[4:20, 4:20] = True
+
+    masked = glcm_features(img, mask=mask, levels=levels, value_range=(0.0, 1.0))
+
+    # Cropping to the mask bounding box and computing without a mask must
+    # match, since every in-mask pair lies inside that crop.
+    crop = img[4:20, 4:20]
+    cropped = glcm_features(crop, levels=levels, value_range=(0.0, 1.0))
+    for prop in masked:
+        assert abs(masked[prop] - cropped[prop]) < 1e-9, prop
+
+
+def test_glcm_constant_region_correlation_is_one() -> None:
+    """A constant image yields correlation 1.0 (matching skimage's std guard)."""
+    img = np.full((16, 16), 7.0)
+    feats = glcm_features(img, levels=8)
+    assert feats["correlation"] == 1.0
+    assert feats["contrast"] == 0.0
+
+
+def test_glcm_rejects_bad_input() -> None:
+    """Invalid ndim, mask shape and levels raise ValueError."""
+    img = np.zeros((4, 4, 4, 4))
+    with pytest.raises(ValueError, match="2D"):
+        glcm_features(img)
+    img2d = np.zeros((8, 8))
+    with pytest.raises(ValueError, match="mask shape"):
+        glcm_features(img2d, mask=np.zeros((4, 4), dtype=bool))
+    with pytest.raises(ValueError, match="levels"):
+        glcm_features(img2d, levels=1)
+
+
+@pytest.mark.parametrize("use_gpu", [False, True])
+def test_glcm_cpu_vs_gpu(use_gpu: bool, gpu_available: bool) -> None:
+    """GLCM features agree between CPU and GPU within tolerance."""
+    rng = np.random.default_rng(5)
+    img = rng.random((40, 50)).astype(np.float32)
+    cpu = glcm_features(img, levels=16)
+
+    if use_gpu:
+        if not gpu_available:
+            pytest.skip("GPU not available")
+        gpu = glcm_features(ascupy(img), levels=16)
+        for prop in cpu:
+            assert abs(cpu[prop] - gpu[prop]) < 1e-4, prop
+    else:
+        for value in cpu.values():
+            assert np.isfinite(value)

--- a/tests/feature/test_texture.py
+++ b/tests/feature/test_texture.py
@@ -6,9 +6,18 @@ from skimage.feature import graycoprops, graycomatrix
 
 from cubic.cuda import ascupy
 from cubic.feature import glcm_features
-from cubic.feature.texture import _PROPS, _unit_offsets
+from cubic.feature.texture import _unit_offsets
 
 _ANGLES = [0, np.pi / 4, np.pi / 2, 3 * np.pi / 4]
+_EXPECTED_PROPS = {
+    "ASM",
+    "energy",
+    "entropy",
+    "contrast",
+    "correlation",
+    "homogeneity",
+    "dissimilarity",
+}
 
 
 def _skimage_reference(image: np.ndarray, levels: int) -> dict[str, float]:
@@ -72,7 +81,7 @@ def test_glcm_3d_runs_and_is_finite() -> None:
     rng = np.random.default_rng(2)
     vol = rng.random((12, 16, 18)).astype(np.float32)
     feats = glcm_features(vol, levels=16)
-    assert set(feats) == set(_PROPS)
+    assert set(feats) == _EXPECTED_PROPS
     for value in feats.values():
         assert np.isfinite(value)
 

--- a/tests/feature/test_texture.py
+++ b/tests/feature/test_texture.py
@@ -127,6 +127,35 @@ def test_glcm_rejects_bad_input() -> None:
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])
+def test_glcm_empty_pair_directions(use_gpu: bool, gpu_available: bool) -> None:
+    """Directions with no valid pairs do not raise (cupy.bincount empty case)."""
+    rng = np.random.default_rng(6)
+    # A single-row image: the vertical directions (1, 0), (1, 1), (1, -1)
+    # have an empty overlap region, so their index arrays are empty.
+    row = rng.random((1, 12)).astype(np.float32)
+    # A single foreground pixel: every direction is fully masked out.
+    img = rng.random((10, 10)).astype(np.float32)
+    mask = np.zeros(img.shape, dtype=bool)
+    mask[5, 5] = True
+
+    if use_gpu:
+        if not gpu_available:
+            pytest.skip("GPU not available")
+        row = ascupy(row)
+        img = ascupy(img)
+        mask = ascupy(mask)
+
+    row_feats = glcm_features(row, levels=8)
+    assert all(np.isfinite(v) for v in row_feats.values())
+
+    masked_feats = glcm_features(img, mask=mask, levels=8)
+    assert all(np.isfinite(v) for v in masked_feats.values())
+    # All directions empty -> all-zero GLCMs -> correlation guard fires.
+    assert masked_feats["correlation"] == 1.0
+    assert masked_feats["contrast"] == 0.0
+
+
+@pytest.mark.parametrize("use_gpu", [False, True])
 def test_glcm_cpu_vs_gpu(use_gpu: bool, gpu_available: bool) -> None:
     """GLCM features agree between CPU and GPU within tolerance."""
     rng = np.random.default_rng(5)

--- a/tests/feature/test_voxel.py
+++ b/tests/feature/test_voxel.py
@@ -37,3 +37,18 @@ def test_regionprops_multiple_labels() -> None:
     labels_out, feats = voxel.extract_features(labels, ["area", "centroid"])
     assert labels_out.tolist() == [1, 2]
     assert feats.shape == (2, 3)
+
+
+def test_regionprops_table_preserves_property_order() -> None:
+    """Output columns follow the requested order with a deduped label last."""
+    labels = np.array([[0, 1, 1], [2, 2, 0]], dtype=np.int32)
+    # Duplicate "area" and omit "label": dedup must keep first occurrence
+    # and append "label" once at the end.
+    props = ["area", "perimeter", "area", "centroid"]
+    out = voxel.regionprops_table(labels, properties=props)
+    keys = list(out.keys())
+
+    assert sum(k == "area" for k in keys) == 1
+    assert keys.index("area") < keys.index("perimeter")
+    assert keys.index("perimeter") < keys.index("centroid-0")
+    assert keys.index("centroid-0") < keys.index("label")

--- a/tests/feature/test_voxel.py
+++ b/tests/feature/test_voxel.py
@@ -52,3 +52,26 @@ def test_regionprops_table_preserves_property_order() -> None:
     assert keys.index("area") < keys.index("perimeter")
     assert keys.index("perimeter") < keys.index("centroid-0")
     assert keys.index("centroid-0") < keys.index("label")
+
+
+def test_regionprops_table_extra_properties() -> None:
+    """extra_properties callables are forwarded and keyed by function name."""
+
+    def intensity_range(regionmask: np.ndarray, intensity: np.ndarray) -> float:
+        values = intensity[regionmask]
+        return float(values.max() - values.min())
+
+    labels = np.array([[0, 1, 1], [2, 2, 0]], dtype=np.int32)
+    intensity = np.array([[0, 10, 20], [5, 5, 0]], dtype=np.float32)
+
+    out = voxel.regionprops_table(
+        labels,
+        intensity_image=intensity,
+        properties=["area"],
+        extra_properties=(intensity_range,),
+    )
+
+    assert "intensity_range" in out
+    by_label = dict(zip(out["label"].tolist(), out["intensity_range"].tolist()))
+    assert by_label[1] == 10.0  # intensities {10, 20}
+    assert by_label[2] == 0.0  # intensities {5, 5}

--- a/tests/feature/test_voxel.py
+++ b/tests/feature/test_voxel.py
@@ -75,3 +75,24 @@ def test_regionprops_table_extra_properties() -> None:
     by_label = dict(zip(out["label"].tolist(), out["intensity_range"].tolist()))
     assert by_label[1] == 10.0  # intensities {10, 20}
     assert by_label[2] == 0.0  # intensities {5, 5}
+
+
+def test_regionprops_extra_properties() -> None:
+    """extra_properties callables are forwarded and exposed as region attributes."""
+
+    def intensity_range(regionmask: np.ndarray, intensity: np.ndarray) -> float:
+        values = intensity[regionmask]
+        return float(values.max() - values.min())
+
+    labels = np.array([[0, 1, 1], [2, 2, 0]], dtype=np.int32)
+    intensity = np.array([[0, 10, 20], [5, 5, 0]], dtype=np.float32)
+
+    regions = voxel.regionprops(
+        labels,
+        intensity_image=intensity,
+        extra_properties=(intensity_range,),
+    )
+
+    by_label = {region.label: region.intensity_range for region in regions}
+    assert by_label[1] == 10.0  # intensities {10, 20}
+    assert by_label[2] == 0.0  # intensities {5, 5}


### PR DESCRIPTION
## Summary

Cubic-side (Part A) of the CP feature-enrichment plan. Adds the texture
and extensibility primitives the dynacell "conventional image" feature
track needs, so the dynacell change (separate VisCy PR) can pin a
released cubic version.

- **`cubic.feature.glcm_features`** (new): device-agnostic Haralick GLCM
  texture features for 2D `(H, W)` and 3D `(D, H, W)` images. cuCIM has
  no `graycomatrix` (rapidsai/cucim#530) and skimage's is 2D-only, so the
  co-occurrence matrix is accumulated with `np.bincount` (works on NumPy
  and CuPy) over the unique half-space directions (4 in 2D, 13 in 3D).
  The seven Haralick properties (contrast, dissimilarity, homogeneity,
  ASM, energy, correlation, entropy) are closed-form reductions that
  reproduce `skimage.feature.graycoprops` **exactly** (≤1e-9 in tests),
  including its correlation near-zero-std guard (→ 1.0, not NaN).
  Quantization is per-image by default (scale-invariant); an explicit
  `value_range` quantizes several regions over shared levels, and an
  optional boolean `mask` restricts counting to foreground pairs.

- **`regionprops` / `regionprops_table` `extra_properties` passthrough**:
  forwards user-defined `func(regionmask, intensity)` callables to the
  underlying skimage/cucim implementation (both accept it), so callers
  can compute custom per-region stats in the same device-agnostic pass.

- **Property-order fix** (`fix:`): `regionprops_table` deduped properties
  with a bare `set()`, whose iteration order depends on the interpreter
  hash seed and so differs per spawned process worker — scrambling output
  column order across workers and misaligning a pooled feature matrix.
  Replaced with order-preserving `list(dict.fromkeys(...))`.

- Version bump `0.7.0a11 → 0.7.0a12`.

## Why

The dynacell CP track extends its per-cell feature matrix with
distribution + texture stats and needs (a) custom `regionprops`
properties, (b) a GLCM texture primitive that works on both CPU and GPU
and in 3D, and (c) deterministic column ordering for the pooled
cross-FOV matrix that feeds FID/KID. None exist in cubic today.

## Tests

`tests/feature/test_texture.py` (new) + `tests/feature/test_voxel.py`:
2D parity vs `graycoprops` for all 7 props, hand-computed entropy,
3D direction count / half-space property, **CPU↔GPU parity** (runs on
this GPU host), affine scale-invariance, mask excludes background pairs,
constant-region correlation = 1.0, input validation; plus
`extra_properties` forwarding and property-order determinism.

## Checks

- `ruff check .` ✅  `ruff format --check` ✅
- `mypy --ignore-missing-imports cubic/` ✅ (no issues, 51 files)
- `pytest` ✅ **327 passed** (315 prior + 12 new; GPU tests executed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add device-agnostic GLCM texture feature extraction and extend region-based feature APIs with custom property support and deterministic output ordering.

New Features:
- Introduce glcm_features for Haralick GLCM texture metrics on 2D and 3D images across CPU and GPU backends.
- Expose glcm_features through the cubic.feature package API.

Bug Fixes:
- Ensure regionprops_table preserves requested property order by using an order-stable de-duplication of properties including label.

Enhancements:
- Add extra_properties passthrough to regionprops and regionprops_table to support user-defined per-region measurements.

Tests:
- Add comprehensive tests for GLCM texture features including parity with skimage, 3D support, scale invariance, masking, CPU/GPU parity, and input validation.
- Add tests verifying regionprops_table column ordering and extra_properties forwarding.

Chores:
- Bump package version from 0.7.0a11 to 0.7.0a12.