### PR TITLE
fix: correctness bug sweep across cubic

### DIFF
--- a/cubic/cuda.py
+++ b/cubic/cuda.py
@@ -106,6 +106,31 @@ def is_gpu_array(array: Any) -> bool:
     )
 
 
+def any_gpu_arg(args: tuple, kwargs: dict) -> bool:
+    """Return True if any positional or keyword argument is a GPU array.
+
+    Device routing in the SciPy / scikit-image proxies must scan *every*
+    argument, not just the first positional one: those libraries take the
+    array under varying names (e.g. ``coordinates``, ``weights``,
+    ``label_image``), so a GPU array elsewhere would otherwise route to the
+    CPU backend and crash on the raw CuPy input.
+    """
+    return any(is_gpu_array(a) for a in args) or any(
+        is_gpu_array(v) for v in kwargs.values()
+    )
+
+
+def coerce_args_to_cpu(args: tuple, kwargs: dict) -> tuple[list, dict]:
+    """Return ``(args, kwargs)`` with every GPU array argument moved to host.
+
+    Non-array arguments pass through untouched. Used by the proxies so a raw
+    CuPy array never reaches a host SciPy / scikit-image function.
+    """
+    cpu_args = [asnumpy(a) if is_gpu_array(a) else a for a in args]
+    cpu_kwargs = {k: asnumpy(v) if is_gpu_array(v) else v for k, v in kwargs.items()}
+    return cpu_args, cpu_kwargs
+
+
 def to_device(array: np.ndarray, device: str) -> np.ndarray:
     """Move array to the requested device."""
     cp = CUDAManager().get_cp()

--- a/cubic/cuda.py
+++ b/cubic/cuda.py
@@ -84,6 +84,28 @@ def get_device(array: np.ndarray) -> str:
     return "CPU"
 
 
+def is_gpu_array(array: Any) -> bool:
+    """Return True if ``array`` is a GPU array (CuPy ndarray or CUDA torch tensor).
+
+    Used by the SciPy / scikit-image proxies to detect the target device across
+    *all* arguments rather than only the first positional one. Uses the same
+    strict ``device`` test as :func:`asnumpy` (a ``cupy.cuda.Device`` exposes
+    ``id``; NumPy 2.x arrays report ``device == "cpu"``), so a non-array object
+    that merely carries a ``device`` attribute is not misclassified.
+    """
+    if _is_torch_tensor(array):
+        return array.device.type == "cuda"  # type: ignore[attr-defined]
+    cp = CUDAManager().get_cp()
+    if cp is None:
+        return False
+    device_val = getattr(array, "device", None)
+    if device_val is None:
+        return False
+    return hasattr(device_val, "id") or (
+        isinstance(device_val, str) and device_val != "cpu"
+    )
+
+
 def to_device(array: np.ndarray, device: str) -> np.ndarray:
     """Move array to the requested device."""
     cp = CUDAManager().get_cp()

--- a/cubic/cuda.py
+++ b/cubic/cuda.py
@@ -88,10 +88,12 @@ def is_gpu_array(array: Any) -> bool:
     """Return True if ``array`` is a GPU array (CuPy ndarray or CUDA torch tensor).
 
     Used by the SciPy / scikit-image proxies to detect the target device across
-    *all* arguments rather than only the first positional one. Uses the same
-    strict ``device`` test as :func:`asnumpy` (a ``cupy.cuda.Device`` exposes
-    ``id``; NumPy 2.x arrays report ``device == "cpu"``), so a non-array object
-    that merely carries a ``device`` attribute is not misclassified.
+    *all* arguments rather than only the first positional one. This is a
+    ``device``-based heuristic, not a type check: a CuPy array (whose ``device``
+    is a ``cupy.cuda.Device`` exposing ``id``) and a CUDA torch tensor classify
+    as GPU; a NumPy 2.x array (``device == "cpu"``) and any object without a
+    ``device`` attribute classify as CPU. Mirroring :func:`asnumpy`, an object
+    whose ``device`` is a non-``"cpu"`` string is also treated as GPU.
     """
     if _is_torch_tensor(array):
         return array.device.type == "cuda"  # type: ignore[attr-defined]

--- a/cubic/feature/mesh.py
+++ b/cubic/feature/mesh.py
@@ -77,6 +77,7 @@ def extract_features(
     """Extract features from a label image using ``trimesh``."""
     label_image = asnumpy(label_image)
     labels = np.unique(label_image)
+    labels = labels[labels != 0]  # exclude background, matching voxel.regionprops
 
     features = features or mesh_feature_list()
     feature_values = []

--- a/cubic/image_utils.py
+++ b/cubic/image_utils.py
@@ -234,7 +234,7 @@ def crop_corner(
         # "b"/"r" crop from the far edge (last/second-to-last axis); everything
         # else (incl. "t"/"l") crops from the near edge.
         crop_from_end = (axis == axes[-1] and "r" in corner) or (
-            axis == axes[-2] and "b" in corner
+            len(axes) >= 2 and axis == axes[-2] and "b" in corner
         )
         if crop_from_end:
             slices[axis] = slice(img.shape[axis] - size, None)

--- a/cubic/image_utils.py
+++ b/cubic/image_utils.py
@@ -143,12 +143,20 @@ def pad_image_to_cube(
 def pad_image_to_shape(
     img: np.ndarray, new_shape: Sequence[int], mode: str = "constant"
 ) -> np.ndarray:
-    """Pad all image axis up to specified shape."""
+    """Pad all image axis up to specified shape.
+
+    Padding is centered to match ``crop_center``'s slicing convention so an
+    odd size difference still reaches the exact target shape (the previous
+    symmetric ``(new - dim) // 2`` on both sides fell one short for odd diffs).
+    """
+    pad_sizes = [(0, 0)] * img.ndim
     for i, dim in enumerate(img.shape):
         if dim < new_shape[i]:
-            pad_size = (new_shape[i] - dim) // 2
-            img = pad_image(img, pad_size=pad_size, axes=i, mode=mode)
+            pad_before = new_shape[i] // 2 - dim // 2
+            pad_after = new_shape[i] - dim - pad_before
+            pad_sizes[i] = (pad_before, pad_after)
 
+    img = np.pad(img, pad_sizes, mode=mode)  # type: ignore[call-overload]
     assert np.all([dim == new_shape[i] for i, dim in enumerate(img.shape)])
     return img
 
@@ -222,19 +230,16 @@ def crop_corner(
         if axis >= img.ndim:
             raise ValueError("Axis index out of range for the image dimensions.")
 
-        if "t" in corner or "l" in corner:
-            start = 0
-            end = size if size <= img.shape[axis] else img.shape[axis]
+        size = min(size, img.shape[axis])
+        # "b"/"r" crop from the far edge (last/second-to-last axis); everything
+        # else (incl. "t"/"l") crops from the near edge.
+        crop_from_end = (axis == axes[-1] and "r" in corner) or (
+            axis == axes[-2] and "b" in corner
+        )
+        if crop_from_end:
+            slices[axis] = slice(img.shape[axis] - size, None)
         else:
-            start = -size if size <= img.shape[axis] else -img.shape[axis]
-            end = None
-
-        if "r" in corner and axis == axes[-1]:
-            slices[axis] = slice(-end if end is not None else None, None)
-        elif "b" in corner and axis == axes[-2]:
-            slices[axis] = slice(-end if end is not None else None, None)
-        else:
-            slices[axis] = slice(start, end)
+            slices[axis] = slice(0, size)
 
     return img[tuple(slices)]
 

--- a/cubic/metrics/average_precision.py
+++ b/cubic/metrics/average_precision.py
@@ -232,8 +232,14 @@ def average_precision(
     if matches_per_threshold is None:
         raise ValueError("No matches found.")
     tp = np.asarray([len(matches_per_threshold[th][0]) for th in thresholds])
-    fp = asnumpy(masks_pred.max()) - tp
-    fn = asnumpy(masks_true.max()) - tp
+    # Count distinct foreground labels rather than using ``.max()``: when the
+    # caller supplies ``matches_per_threshold`` the sequential-label check in
+    # ``compute_matches`` is skipped, so a gap in the label ids would make
+    # ``.max()`` over-count objects and corrupt FP/FN/AP.
+    n_pred = int((np.unique(masks_pred) != 0).sum())
+    n_true = int((np.unique(masks_true) != 0).sum())
+    fp = n_pred - tp
+    fn = n_true - tp
 
     sum_counts = tp + fp + fn
     ap = np.where(sum_counts > 0, tp / sum_counts, 0)

--- a/cubic/metrics/feature.py
+++ b/cubic/metrics/feature.py
@@ -43,7 +43,10 @@ def get_true_features(
                 )
             )
         else:
-            assert all(feat in gt_features for feat in features if feat != "label"), (
+            # gt_features holds expanded column names (e.g. "centroid-0"); compare
+            # against their base names so vector properties like "centroid" match.
+            gt_base = {feat.split("-")[0] for feat in gt_features if feat != "label"}
+            assert all(feat in gt_base for feat in features if feat != "label"), (
                 "Some features not found in precomputed features."
             )
 

--- a/cubic/metrics/ms_ssim.py
+++ b/cubic/metrics/ms_ssim.py
@@ -54,6 +54,16 @@ def _avgpool2(x: np.ndarray) -> np.ndarray:
     )
 
 
+def _crop_slice(ndim: int, pad: int) -> tuple:
+    """Build a spatial-only center crop of ``pad`` on each edge.
+
+    ``pad == 0`` yields a no-op (``slice(None)``) instead of the empty
+    ``slice(0, -0)`` that bare ``slice(pad, -pad)`` would produce.
+    """
+    edge = slice(pad, -pad) if pad else slice(None)
+    return (slice(None),) * (ndim - 2) + (edge, edge)
+
+
 def _torchmetrics_ssim_update(
     image1: np.ndarray,
     image2: np.ndarray,
@@ -62,9 +72,8 @@ def _torchmetrics_ssim_update(
     c2: float,
     kernel_size: int,
     sigma: float,
-    truncate: float,
-) -> tuple[float, float]:
-    """Compute ``(ssim_full_mean, cs_cropped_mean)`` per torchmetrics' ``_ssim_update``.
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute per-image ``(ssim_full, cs_cropped)`` means per torchmetrics' ``_ssim_update``.
 
     Torchmetrics' boundary handling is **explicit pad + valid conv**
     (``ssim.py:142-154``): ``F.pad(x, mode="reflect", pad=(pad, ...))``
@@ -82,6 +91,14 @@ def _torchmetrics_ssim_update(
        region — i.e. equivalent to a "valid" convolution on padded input.
     3. Slice back to the original spatial extent.
 
+    The Gaussian kernel width is tied to ``kernel_size`` (matching
+    torchmetrics, which builds a ``kernel_size``-wide kernel shaped by
+    ``sigma``): skimage's ``truncate`` is derived as ``pad / sigma`` so its
+    radius equals ``pad`` and the kernel spans exactly ``kernel_size``. This
+    keeps the pad, crop, and kernel consistent for *any* odd ``kernel_size``
+    (a fixed ``truncate`` desynced them, leaking ``cval=0`` into the valid
+    region for ``kernel_size`` below the Gaussian radius).
+
     Variance uses the **population** estimator (no ``NP / (NP - 1)``
     factor). ``vx`` and ``vy`` are clamped to ``>= 0`` to absorb
     round-off noise (matches torchmetrics ``ssim.py:163-164``); ``vxy``
@@ -96,23 +113,24 @@ def _torchmetrics_ssim_update(
         ``(K2 * data_range) ** 2``.
     kernel_size : int
         Gaussian kernel side; must be odd-positive. Pad width is
-        ``(kernel_size - 1) // 2``.
+        ``(kernel_size - 1) // 2`` and governs the kernel width.
     sigma : float
         Gaussian standard deviation.
-    truncate : float
-        Gaussian truncation radius in units of ``sigma``, sized so the
-        kernel exactly fits the pad width.
 
     Returns
     -------
-    tuple of float
-        ``(ssim_full_mean, cs_cropped_mean)``. The SSIM map is averaged
-        over the full (un-further-cropped) slice; the contrast-sensitivity
-        map is averaged over an additional ``[pad:-pad, pad:-pad]``
-        crop — matches ``torchmetrics ssim.py:177``.
+    tuple of numpy.ndarray
+        ``(ssim_full_mean, cs_cropped_mean)``, each reduced over the
+        spatial axes only — a scalar for ``(H, W)`` input or shape ``(N,)``
+        for ``(N, H, W)`` input, so callers can reduce per image rather
+        than pooling the whole batch. The CS map is averaged over an
+        additional ``[pad:-pad, pad:-pad]`` crop (``torchmetrics ssim.py:177``).
     """
     pad = (kernel_size - 1) // 2
-    # Pad only the spatial axes (last two); leave the batch axis alone.
+    # Tie skimage's Gaussian radius to ``pad`` so the kernel is exactly
+    # ``kernel_size`` wide regardless of ``kernel_size`` (radius == pad).
+    truncate = pad / sigma if sigma > 0 else 0.0
+
     pad_widths = [(0, 0)] * (image1.ndim - 2) + [(pad, pad), (pad, pad)]
     i1p = np.pad(image1, pad_widths, mode="reflect")
     i2p = np.pad(image2, pad_widths, mode="reflect")
@@ -131,7 +149,7 @@ def _torchmetrics_ssim_update(
     uxy_p = _filter(i1p * i2p)
 
     # Slice back to the original spatial extent.
-    sl = (slice(None),) * (image1.ndim - 2) + (slice(pad, -pad), slice(pad, -pad))
+    sl = _crop_slice(image1.ndim, pad)
     ux = ux_p[sl]
     uy = uy_p[sl]
     uxx = uxx_p[sl]
@@ -149,14 +167,11 @@ def _torchmetrics_ssim_update(
     ssim_full = ((2.0 * ux * uy + c1) * upper) / ((ux * ux + uy * uy + c1) * lower)
 
     # CS is further cropped by `pad` to match torchmetrics ssim.py:177.
-    cs_full = upper / lower
-    sl_cs = (slice(None),) * (image1.ndim - 2) + (
-        slice(pad, -pad),
-        slice(pad, -pad),
-    )
-    cs_cropped = cs_full[sl_cs]
+    cs_cropped = (upper / lower)[_crop_slice(image1.ndim, pad)]
 
-    return float(ssim_full.mean()), float(cs_cropped.mean())
+    # Reduce over spatial axes only; keep the batch axis so MS-SSIM can be
+    # averaged per image (matches torchmetrics' elementwise_mean reduction).
+    return ssim_full.mean(axis=(-2, -1)), cs_cropped.mean(axis=(-2, -1))
 
 
 def ms_ssim(
@@ -167,7 +182,6 @@ def ms_ssim(
     betas: tuple[float, ...] = DEFAULT_BETAS,
     kernel_size: int = 11,
     sigma: float = 1.5,
-    truncate: float = 3.5,
     K1: float = 0.01,
     K2: float = 0.03,
     normalize: str = "relu",
@@ -180,6 +194,12 @@ def ms_ssim(
     and multiplied; at the coarsest scale the full SSIM map is used
     instead. Downsampling between scales is 2x2 average pooling.
 
+    For ``(N, H, W)`` input the per-scale maps are reduced per image and the
+    MS-SSIM product is formed per image, then averaged over the batch — i.e.
+    ``mean_n(prod_j ...)``, matching torchmetrics' ``elementwise_mean``. (An
+    earlier version pooled the maps across the whole batch before taking the
+    product, which is not the same for dissimilar slices.)
+
     Parameters
     ----------
     image1, image2 : numpy.ndarray
@@ -190,11 +210,10 @@ def ms_ssim(
         Per-scale weights, finest → coarsest. The number of scales is
         ``len(betas)``.
     kernel_size : int, default=11
-        Gaussian kernel side; must be odd-positive.
+        Gaussian kernel side; must be odd-positive. Governs the Gaussian
+        kernel width (shaped by ``sigma``), matching torchmetrics.
     sigma : float, default=1.5
         Gaussian standard deviation.
-    truncate : float, default=3.5
-        Gaussian truncation radius in units of ``sigma``.
     K1, K2 : float, default=0.01, 0.03
         SSIM stability constants.
     normalize : str, default="relu"
@@ -205,7 +224,7 @@ def ms_ssim(
     Returns
     -------
     float
-        Scalar MS-SSIM value.
+        Scalar MS-SSIM value (mean over the batch for ``(N, H, W)`` input).
 
     Raises
     ------
@@ -243,8 +262,8 @@ def ms_ssim(
     c1 = (K1 * data_range) ** 2
     c2 = (K2 * data_range) ** 2
 
-    cs_powers: list[float] = []
-    final: float = 1.0
+    # Per-image accumulators (scalar for (H, W), shape (N,) for (N, H, W)).
+    ms_per_image: np.ndarray | float = 1.0
     for j in range(n_scales):
         ssim_full, cs_cropped = _torchmetrics_ssim_update(
             image1,
@@ -253,17 +272,16 @@ def ms_ssim(
             c2=c2,
             kernel_size=kernel_size,
             sigma=sigma,
-            truncate=truncate,
         )
         if j < n_scales - 1:
             if normalize == "relu":
-                cs_cropped = max(cs_cropped, 0.0)
-            cs_powers.append(cs_cropped ** betas[j])
+                cs_cropped = np.maximum(cs_cropped, 0.0)
+            ms_per_image = ms_per_image * (cs_cropped ** betas[j])
             image1 = _avgpool2(image1)
             image2 = _avgpool2(image2)
         else:
             if normalize == "relu":
-                ssim_full = max(ssim_full, 0.0)
-            final = ssim_full ** betas[j]
+                ssim_full = np.maximum(ssim_full, 0.0)
+            ms_per_image = ms_per_image * (ssim_full ** betas[j])
 
-    return float(final * float(np.prod(cs_powers)))
+    return float(np.mean(ms_per_image))

--- a/cubic/metrics/ms_ssim.py
+++ b/cubic/metrics/ms_ssim.py
@@ -230,9 +230,10 @@ def ms_ssim(
     ------
     ValueError
         If ``image1.shape != image2.shape``, ``image1.ndim`` is not 2 or
-        3, ``kernel_size`` is not odd-positive, ``data_range`` is not
-        finite-positive, or any spatial dim is below
-        ``2 ** (n_scales - 1) * kernel_size`` (176 for the defaults).
+        3, ``kernel_size`` is not odd-positive, ``sigma`` is not
+        finite-positive, ``data_range`` is not finite-positive, or any
+        spatial dim is below ``2 ** (n_scales - 1) * kernel_size`` (176 for
+        the defaults).
     """
     check_same_device(image1, image2)
 
@@ -247,6 +248,8 @@ def ms_ssim(
         )
     if kernel_size < 1 or kernel_size % 2 == 0:
         raise ValueError(f"kernel_size must be odd and positive; got {kernel_size}")
+    if not (np.isfinite(sigma) and sigma > 0):
+        raise ValueError(f"sigma must be finite and positive; got {sigma}")
     if not (np.isfinite(data_range) and data_range > 0):
         raise ValueError(f"data_range must be finite and positive; got {data_range}")
 

--- a/cubic/metrics/ms_ssim.py
+++ b/cubic/metrics/ms_ssim.py
@@ -167,7 +167,7 @@ def _torchmetrics_ssim_update(
     ssim_full = ((2.0 * ux * uy + c1) * upper) / ((ux * ux + uy * uy + c1) * lower)
 
     # CS is further cropped by `pad` to match torchmetrics ssim.py:177.
-    cs_cropped = (upper / lower)[_crop_slice(image1.ndim, pad)]
+    cs_cropped = (upper / lower)[sl]
 
     # Reduce over spatial axes only; keep the batch axis so MS-SSIM can be
     # averaged per image (matches torchmetrics' elementwise_mean reduction).

--- a/cubic/metrics/spectral/radial.py
+++ b/cubic/metrics/spectral/radial.py
@@ -69,9 +69,14 @@ def _radial_edges_cached(
         raise ValueError("bin_delta must be > 0")
 
     if spacing_key is None:
-        # Index units: step = bin_delta, kmax = floor(n/2)
+        # Index units: step = bin_delta, kmax = floor(n/2).
+        # Honor use_max_nyquist (max axis Nyquist) so sectioned callers that
+        # normalize by max(n // 2) reach 1.0 on anisotropic shapes; otherwise
+        # the XY-sector curve is compressed into the low-frequency quarter.
         step = float(bin_delta)
-        kmax = _kmax_index(shape)
+        kmax = (
+            float(max(n // 2 for n in shape)) if use_max_nyquist else _kmax_index(shape)
+        )
     else:
         # Physical units: one index bin in physical units along axis i: Δk_i = 1/(n_i·spacing_i)
         dk_min = min(1.0 / (n * sp) for n, sp in zip(shape, spacing_key))

--- a/cubic/plot_utils.py
+++ b/cubic/plot_utils.py
@@ -37,6 +37,6 @@ def show_image_error(
 ) -> Figure:
     """Display error map between teo images."""
     fig = plt.figure(figsize=figsize)
-    plt.imshow(img, cmap=cmap, vmin=(-(2**bit_depth) - 1), vmax=(2**bit_depth - 1))
+    plt.imshow(img, cmap=cmap, vmin=-(2**bit_depth - 1), vmax=(2**bit_depth - 1))
     plt.axis("off")
     return fig

--- a/cubic/plot_utils.py
+++ b/cubic/plot_utils.py
@@ -35,7 +35,7 @@ def show_image_error(
     bit_depth: int = 14,
     cmap: str = "bwr",
 ) -> Figure:
-    """Display error map between teo images."""
+    """Display error map between two images."""
     fig = plt.figure(figsize=figsize)
     plt.imshow(img, cmap=cmap, vmin=-(2**bit_depth - 1), vmax=(2**bit_depth - 1))
     plt.axis("off")

--- a/cubic/preprocessing/deconvolution.py
+++ b/cubic/preprocessing/deconvolution.py
@@ -36,9 +36,14 @@ def richardson_lucy_skimage(
     if observer_fn is None:
         return rl_partial(image, num_iter=n_iter)
 
+    # Recompute from the original image at each depth so each observed estimate
+    # is the true i-iteration RL result and the returned value matches the
+    # no-observer path. Looping with ``num_iter=1`` on the previous output
+    # instead both re-clips every iteration (skimage clips per call) and feeds
+    # the deconvolution back as the image, diverging from a single call.
     estimate = image
     for i in range(1, n_iter + 1):
-        estimate = rl_partial(estimate, num_iter=1)
+        estimate = rl_partial(image, num_iter=i)
         observer_fn(estimate, i)
 
     return estimate
@@ -64,9 +69,7 @@ def decon_skimage(
     if observer_fn is not None:
 
         def wrapper_observer(restored_image, i, *args):
-            processed_image = restored_image[
-                pad_size_z : image.shape[0] + pad_size_z, :, :
-            ]
+            processed_image = restored_image[pad_size_z : image.shape[0] + pad_size_z]
             observer_fn(processed_image, i, *args)
 
     decon_image = richardson_lucy_skimage(
@@ -78,7 +81,7 @@ def decon_skimage(
         filter_epsilon=filter_epsilon,
     )
 
-    decon_image = decon_image[pad_size_z : image.shape[0] + pad_size_z, :, :]
+    decon_image = decon_image[pad_size_z : image.shape[0] + pad_size_z]
     return decon_image
 
 
@@ -103,9 +106,7 @@ def decon_xpy(
     if observer_fn is not None:
 
         def wrapper_observer(restored_image, i, *args):
-            processed_image = restored_image[
-                pad_size_z : image.shape[0] + pad_size_z, :, :
-            ]
+            processed_image = restored_image[pad_size_z : image.shape[0] + pad_size_z]
             observer_fn(processed_image, i, *args)
 
     decon_image = richardson_lucy_xp(
@@ -117,7 +118,7 @@ def decon_xpy(
         observer_fn=wrapper_observer,
     )
 
-    decon_image = decon_image[pad_size_z : image.shape[0] + pad_size_z, :, :]
+    decon_image = decon_image[pad_size_z : image.shape[0] + pad_size_z]
     return decon_image
 
 

--- a/cubic/scipy.py
+++ b/cubic/scipy.py
@@ -3,11 +3,23 @@
 import warnings
 from types import ModuleType
 from typing import Any
-from functools import wraps
 from importlib import import_module
 from collections.abc import Callable
 
-from .cuda import CUDAManager, asnumpy, to_device
+from .cuda import CUDAManager, asnumpy, to_device, is_gpu_array
+
+
+def _any_gpu_arg(args: tuple, kwargs: dict) -> bool:
+    """Return True if any positional or keyword argument is a GPU array.
+
+    Device routing must scan *every* argument, not just ``args[0]`` /
+    ``kwargs["input"]``: SciPy functions take the array under varying names
+    (e.g. ``coordinates``, ``weights``), so a GPU array elsewhere would
+    otherwise route to CPU SciPy and crash on the raw CuPy input.
+    """
+    return any(is_gpu_array(a) for a in args) or any(
+        is_gpu_array(v) for v in kwargs.values()
+    )
 
 
 class SciPyProxy(ModuleType):
@@ -26,15 +38,28 @@ class SciPyProxy(ModuleType):
             return self.__dict__[func_name]
 
         def func_wrapper(*args: Any, **kwargs: Any) -> Any:
-            array = args[0] if args else kwargs.get("input", None)
-            use_gpu = False
-            if self.cp is not None and hasattr(array, "device"):
-                device_val = getattr(array, "device", None)
-                use_gpu = hasattr(device_val, "id") or (
-                    isinstance(device_val, str) and device_val != "cpu"
-                )
+            use_gpu = self.cp is not None and _any_gpu_arg(args, kwargs)
             base_module = "cupyx.scipy" if use_gpu else "scipy"
             module_name = f"{base_module}.{self.__name__}"
+
+            def _on_cpu(func: Callable, return_to_gpu: bool) -> Any:
+                # Coerce every GPU array argument to CPU before calling SciPy,
+                # then optionally move array results back to the GPU.
+                cpu_args = [asnumpy(a) if is_gpu_array(a) else a for a in args]
+                cpu_kwargs = {
+                    k: asnumpy(v) if is_gpu_array(v) else v for k, v in kwargs.items()
+                }
+                result = func(*cpu_args, **cpu_kwargs)
+                if not return_to_gpu:
+                    return result
+                if isinstance(result, tuple):
+                    return tuple(
+                        to_device(r, "GPU") if hasattr(r, "dtype") else r
+                        for r in result
+                    )
+                if hasattr(result, "dtype"):
+                    return to_device(result, "GPU")
+                return result
 
             try:
                 module = import_module(module_name)
@@ -43,36 +68,14 @@ class SciPyProxy(ModuleType):
                 warnings.warn(
                     f"cupyx.scipy.{self.__name__}.{func_name} is unavailable, falling back to CPU."
                 )
-                module = import_module(f"scipy.{self.__name__}")
-                func = getattr(module, func_name)
+                func = getattr(import_module(f"scipy.{self.__name__}"), func_name)
+                return _on_cpu(func, return_to_gpu=use_gpu)
 
-                @wraps(func)
-                def inner_cpu(*cargs: Any, **ckwargs: Any) -> Any:
-                    cpu_args = [
-                        asnumpy(a) if hasattr(a, "device") else a for a in cargs
-                    ]
-                    cpu_kwargs = {
-                        k: asnumpy(v) if hasattr(v, "device") else v
-                        for k, v in ckwargs.items()
-                    }
-                    result = func(*cpu_args, **cpu_kwargs)
-                    if use_gpu:
-                        if isinstance(result, tuple):
-                            return tuple(
-                                to_device(r, "GPU") if hasattr(r, "dtype") else r
-                                for r in result
-                            )
-                        if hasattr(result, "dtype"):
-                            return to_device(result, "GPU")
-                    return result
-
-                return inner_cpu(*args, **kwargs)
-
-            @wraps(func)
-            def inner(*cargs: Any, **ckwargs: Any) -> Any:
-                return func(*cargs, **ckwargs)
-
-            return inner(*args, **kwargs)
+            if not use_gpu:
+                # CPU route: defensively coerce any stray GPU array to CPU so a
+                # raw CuPy array never reaches a host SciPy function.
+                return _on_cpu(func, return_to_gpu=False)
+            return func(*args, **kwargs)
 
         self.__dict__[func_name] = func_wrapper
         return func_wrapper

--- a/cubic/scipy.py
+++ b/cubic/scipy.py
@@ -6,20 +6,7 @@ from typing import Any
 from importlib import import_module
 from collections.abc import Callable
 
-from .cuda import CUDAManager, asnumpy, to_device, is_gpu_array
-
-
-def _any_gpu_arg(args: tuple, kwargs: dict) -> bool:
-    """Return True if any positional or keyword argument is a GPU array.
-
-    Device routing must scan *every* argument, not just ``args[0]`` /
-    ``kwargs["input"]``: SciPy functions take the array under varying names
-    (e.g. ``coordinates``, ``weights``), so a GPU array elsewhere would
-    otherwise route to CPU SciPy and crash on the raw CuPy input.
-    """
-    return any(is_gpu_array(a) for a in args) or any(
-        is_gpu_array(v) for v in kwargs.values()
-    )
+from .cuda import CUDAManager, to_device, any_gpu_arg, coerce_args_to_cpu
 
 
 class SciPyProxy(ModuleType):
@@ -38,17 +25,14 @@ class SciPyProxy(ModuleType):
             return self.__dict__[func_name]
 
         def func_wrapper(*args: Any, **kwargs: Any) -> Any:
-            use_gpu = self.cp is not None and _any_gpu_arg(args, kwargs)
+            use_gpu = self.cp is not None and any_gpu_arg(args, kwargs)
             base_module = "cupyx.scipy" if use_gpu else "scipy"
             module_name = f"{base_module}.{self.__name__}"
 
             def _on_cpu(func: Callable, return_to_gpu: bool) -> Any:
                 # Coerce every GPU array argument to CPU before calling SciPy,
                 # then optionally move array results back to the GPU.
-                cpu_args = [asnumpy(a) if is_gpu_array(a) else a for a in args]
-                cpu_kwargs = {
-                    k: asnumpy(v) if is_gpu_array(v) else v for k, v in kwargs.items()
-                }
+                cpu_args, cpu_kwargs = coerce_args_to_cpu(args, kwargs)
                 result = func(*cpu_args, **cpu_kwargs)
                 if not return_to_gpu:
                     return result

--- a/cubic/segmentation/_clear_border.py
+++ b/cubic/segmentation/_clear_border.py
@@ -90,7 +90,7 @@ def clear_border(
             f"are {out.shape} and {mask.shape}"
         )
         if out.shape != mask.shape:
-            raise (ValueError, err_msg)
+            raise ValueError(err_msg)
         if mask.dtype != bool:
             raise TypeError("mask should be of type bool.")
         borders = ~mask

--- a/cubic/segmentation/segment_utils.py
+++ b/cubic/segmentation/segment_utils.py
@@ -283,24 +283,28 @@ def clear_xy_borders(label_image: np.ndarray, buffer_size: int = 0) -> np.ndarra
 def remove_touching_objects(
     label_image: np.ndarray, border_value: int = 100
 ) -> np.ndarray:
-    """Find labelled masks that overlap and remove from the image."""
+    """Find labelled masks that touch each other and remove them.
+
+    ``border_value`` is accepted for backwards compatibility but no longer
+    used: neighbouring labels are read directly from each object's dilated
+    outline. The previous additive-offset trick misclassified any label id
+    greater than ``border_value`` (Cellpose routinely emits hundreds of
+    labels), which silently deleted non-touching objects.
+    """
     check_labeled_binary(label_image)
 
-    exclude_masks = []
+    exclude_masks: list[int] = []
     for mask_idx in np.unique(label_image)[1:]:
-        if mask_idx not in exclude_masks:
-            binary_mask = label_image == mask_idx
-            dilated_mask = morphology.binary_dilation(binary_mask, morphology.cube(3))
-            mask_outline = dilated_mask & ~binary_mask
+        if mask_idx in exclude_masks:
+            continue
+        binary_mask = label_image == mask_idx
+        dilated_mask = morphology.binary_dilation(binary_mask, morphology.cube(3))
+        mask_outline = dilated_mask & ~binary_mask
 
-            masks_copy = label_image.copy()
-            masks_copy[mask_outline] += border_value
-
-            if masks_copy[masks_copy > border_value].sum() > 0:
-                overlap_masks = (
-                    np.unique(masks_copy[masks_copy > border_value]) - border_value
-                )
-                exclude_masks += [mask_idx] + list(overlap_masks)
+        neighbor_ids = np.unique(label_image[mask_outline])
+        neighbor_ids = neighbor_ids[neighbor_ids != 0]
+        if neighbor_ids.size > 0:
+            exclude_masks += [int(mask_idx), *(int(n) for n in neighbor_ids)]
 
     for exclude_mask in exclude_masks:
         label_image[label_image == exclude_mask] = 0

--- a/cubic/segmentation/segment_utils.py
+++ b/cubic/segmentation/segment_utils.py
@@ -293,9 +293,9 @@ def remove_touching_objects(
     """
     check_labeled_binary(label_image)
 
-    exclude_masks: list[int] = []
+    exclude_masks: set[int] = set()
     for mask_idx in np.unique(label_image)[1:]:
-        if mask_idx in exclude_masks:
+        if int(mask_idx) in exclude_masks:
             continue
         binary_mask = label_image == mask_idx
         dilated_mask = morphology.binary_dilation(binary_mask, morphology.cube(3))
@@ -304,7 +304,8 @@ def remove_touching_objects(
         neighbor_ids = np.unique(label_image[mask_outline])
         neighbor_ids = neighbor_ids[neighbor_ids != 0]
         if neighbor_ids.size > 0:
-            exclude_masks += [int(mask_idx), *(int(n) for n in neighbor_ids)]
+            exclude_masks.add(int(mask_idx))
+            exclude_masks.update(int(n) for n in neighbor_ids)
 
     for exclude_mask in exclude_masks:
         label_image[label_image == exclude_mask] = 0

--- a/cubic/skimage.py
+++ b/cubic/skimage.py
@@ -5,7 +5,7 @@ from typing import Any
 from importlib import import_module
 from collections.abc import Callable
 
-from .cuda import CUDAManager, asnumpy, is_gpu_array
+from .cuda import CUDAManager, any_gpu_arg, coerce_args_to_cpu
 
 
 class SkimageProxy(ModuleType):
@@ -34,10 +34,7 @@ class SkimageProxy(ModuleType):
                 base_module = "cubic.cucim"
                 use_gpu = False
             else:
-                use_gpu = self.cp is not None and (
-                    any(is_gpu_array(a) for a in args)
-                    or any(is_gpu_array(v) for v in kwargs.values())
-                )
+                use_gpu = self.cp is not None and any_gpu_arg(args, kwargs)
                 base_module = "cucim.skimage" if use_gpu else "skimage"
 
             full_func_name = f"{base_module}.{self.__name__}.{func_name}"
@@ -48,10 +45,7 @@ class SkimageProxy(ModuleType):
                 return func(*args, **kwargs)
             # CPU route: defensively coerce any stray GPU array to CPU so a raw
             # CuPy array never reaches a host scikit-image function.
-            cpu_args = [asnumpy(a) if is_gpu_array(a) else a for a in args]
-            cpu_kwargs = {
-                k: asnumpy(v) if is_gpu_array(v) else v for k, v in kwargs.items()
-            }
+            cpu_args, cpu_kwargs = coerce_args_to_cpu(args, kwargs)
             return func(*cpu_args, **cpu_kwargs)
 
         self.__dict__[func_name] = func_wrapper

--- a/cubic/skimage.py
+++ b/cubic/skimage.py
@@ -2,11 +2,10 @@
 
 from types import ModuleType
 from typing import Any
-from functools import wraps
 from importlib import import_module
 from collections.abc import Callable
 
-from .cuda import CUDAManager
+from .cuda import CUDAManager, asnumpy, is_gpu_array
 
 
 class SkimageProxy(ModuleType):
@@ -26,32 +25,34 @@ class SkimageProxy(ModuleType):
 
         def func_wrapper(*args: Any, **kwargs: Any) -> Any:
             """Wrap skimage or cucim functions based on device capability."""
-            base_module = "skimage"
-
+            # The io submodule routes to cubic.cucim, which manages device
+            # placement itself. Everything else dispatches on whether *any*
+            # argument is a GPU array — not just the first positional one,
+            # since skimage functions accept the array under varying names
+            # (e.g. ``label_image``, ``intensity_image``, ``coords``).
             if self.__name__ == "io":
                 base_module = "cubic.cucim"
-                array = args[1] if len(args) > 1 else kwargs.get("arr", None)
+                use_gpu = False
             else:
-                array = args[0] if args else kwargs.get("image", None)
-
-                if self.cp is not None and hasattr(array, "device"):
-                    device_val = getattr(array, "device", None)
-                    if hasattr(device_val, "id") or (
-                        isinstance(device_val, str) and device_val != "cpu"
-                    ):
-                        base_module = "cucim.skimage"
+                use_gpu = self.cp is not None and (
+                    any(is_gpu_array(a) for a in args)
+                    or any(is_gpu_array(v) for v in kwargs.values())
+                )
+                base_module = "cucim.skimage" if use_gpu else "skimage"
 
             full_func_name = f"{base_module}.{self.__name__}.{func_name}"
             module_name, method_name = full_func_name.rsplit(".", maxsplit=1)
-            module = import_module(module_name)
-            func = getattr(module, method_name)
+            func = getattr(import_module(module_name), method_name)
 
-            @wraps(func)
-            def inner_func(*args: Any, **kwargs: Any) -> Any:
-                """Inner function to call the wrapped function."""
+            if use_gpu or self.__name__ == "io":
                 return func(*args, **kwargs)
-
-            return inner_func(*args, **kwargs)
+            # CPU route: defensively coerce any stray GPU array to CPU so a raw
+            # CuPy array never reaches a host scikit-image function.
+            cpu_args = [asnumpy(a) if is_gpu_array(a) else a for a in args]
+            cpu_kwargs = {
+                k: asnumpy(v) if is_gpu_array(v) else v for k, v in kwargs.items()
+            }
+            return func(*cpu_args, **cpu_kwargs)
 
         self.__dict__[func_name] = func_wrapper
         return func_wrapper

--- a/tests/feature/test_mesh.py
+++ b/tests/feature/test_mesh.py
@@ -1,0 +1,39 @@
+"""Tests for mesh-based feature extraction."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("trimesh")
+
+from cubic.feature import mesh  # noqa: E402
+
+
+def test_extract_features_excludes_background_label(monkeypatch) -> None:
+    """Background (label 0) produces no row, matching voxel.regionprops.
+
+    Previously ``np.unique`` kept 0, so a meaningless background mesh and a
+    spurious ``label == 0`` row were emitted alongside the real objects. The
+    per-label surface computation is stubbed so the test targets the label
+    filtering without depending on trimesh's optional ``rtree`` backend.
+    """
+    names = mesh.mesh_feature_list()
+    seen_masks: list[int] = []
+
+    def fake_surface_features(mask: np.ndarray) -> dict[str, float]:
+        # Record which label each call corresponds to (mask sum is unique here).
+        seen_masks.append(int(mask.sum()))
+        return dict.fromkeys(names, 0.0)
+
+    monkeypatch.setattr(mesh, "extract_surface_features", fake_surface_features)
+
+    volume = np.zeros((12, 12, 12), dtype=np.int32)
+    volume[2:6, 2:6, 2:6] = 1  # 64 voxels
+    volume[7:11, 7:11, 7:11] = 2  # 64 voxels
+
+    labels, feature_values = mesh.extract_features(volume)
+
+    assert sorted(labels.tolist()) == [1, 2]
+    assert 0 not in labels.tolist()
+    assert feature_values.shape[0] == 2
+    # Background (label 0) mask sum would be 12**3 - 128 = 1600; never visited.
+    assert 1600 not in seen_masks

--- a/tests/metrics/microssim/test_ms_ssim.py
+++ b/tests/metrics/microssim/test_ms_ssim.py
@@ -76,6 +76,25 @@ def test_accepts_3d_input():
     assert isinstance(out, float)
 
 
+def test_batch_equals_mean_of_per_image():
+    """``(N, H, W)`` MS-SSIM is the mean of per-image scores, not a batch pool.
+
+    The slices are deliberately dissimilar so that pooling the maps across the
+    batch (the old behavior) would diverge from the per-image mean.
+    """
+    rng = np.random.default_rng(11)
+    gt = rng.random((3, 256, 256)).astype(np.float64)
+    pred = gt.copy()
+    pred[0] += 0.02 * rng.standard_normal(gt[0].shape)  # near-identical
+    pred[1] = rng.random((256, 256))  # unrelated
+    pred[2] += 0.2 * rng.standard_normal(gt[2].shape)  # noisy
+    dr = float(gt.max() - gt.min())
+
+    per_image = [float(ms_ssim(pred[i], gt[i], data_range=dr)) for i in range(3)]
+    batched = ms_ssim(pred, gt, data_range=dr)
+    assert abs(batched - float(np.mean(per_image))) < 1e-9
+
+
 def test_rejects_1d_input():
     """``ndim=1`` raises ``ValueError``."""
     a = np.zeros(256, dtype=np.float32)
@@ -213,3 +232,32 @@ def test_ms_ssim_matches_torchmetrics():
             f"[{name}] ours={ours:.6f} theirs={theirs:.6f} "
             f"diff={abs(ours - theirs):.6e}"
         )
+
+
+@pytest.mark.parametrize("kernel_size", [7, 9])
+def test_ms_ssim_matches_torchmetrics_non_default_kernel(kernel_size: int):
+    """Non-default ``kernel_size`` matches torchmetrics within 1e-3.
+
+    Guards the desync where the reflect-pad/crop tracked ``kernel_size`` while
+    the Gaussian radius was fixed by ``sigma``/``truncate``: for a smaller
+    kernel the Gaussian leaked ``cval=0`` into the valid region.
+    """
+    pytest.importorskip("torchmetrics")
+    torch = pytest.importorskip("torch")
+    from torchmetrics.image import MultiScaleStructuralSimilarityIndexMeasure
+
+    rng = np.random.default_rng(0)
+    img = rng.random((256, 256)).astype(np.float32)
+    pred = img + 0.05 * rng.standard_normal(img.shape).astype(np.float32)
+    dr = _data_range(img)
+
+    ours = ms_ssim(pred, img, data_range=dr, kernel_size=kernel_size)
+    m = MultiScaleStructuralSimilarityIndexMeasure(
+        data_range=dr, kernel_size=kernel_size
+    )
+    theirs = float(
+        m(torch.from_numpy(pred[None, None]), torch.from_numpy(img[None, None]))
+    )
+    assert abs(ours - theirs) < 1e-3, (
+        f"kernel_size={kernel_size} ours={ours:.6f} theirs={theirs:.6f}"
+    )

--- a/tests/metrics/spectral/test_radial.py
+++ b/tests/metrics/spectral/test_radial.py
@@ -1,0 +1,30 @@
+"""Tests for radial bin-edge construction."""
+
+import numpy as np
+
+from cubic.metrics.spectral.radial import radial_edges
+
+
+def test_radial_edges_index_units_honor_use_max_nyquist() -> None:
+    """use_max_nyquist extends index-unit edges to the max axis Nyquist.
+
+    For an anisotropic shape with no spacing the radial bins must reach
+    ``max(n // 2)`` when requested, so sectioned callers that normalize by the
+    XY Nyquist span the full [0, 1] range instead of being compressed into the
+    low-frequency quarter.
+    """
+    shape = (16, 64, 64)  # min(n//2)=8, max(n//2)=32
+
+    edges_min, _ = radial_edges(shape, spacing=None, use_max_nyquist=False)
+    edges_max, _ = radial_edges(shape, spacing=None, use_max_nyquist=True)
+
+    assert edges_min[-1] == 8.0
+    assert edges_max[-1] == 32.0
+
+
+def test_radial_edges_isotropic_unaffected() -> None:
+    """For isotropic shapes the flag is a no-op (min == max Nyquist)."""
+    shape = (64, 64)
+    edges_min, _ = radial_edges(shape, spacing=None, use_max_nyquist=False)
+    edges_max, _ = radial_edges(shape, spacing=None, use_max_nyquist=True)
+    assert edges_min[-1] == edges_max[-1] == 32.0

--- a/tests/metrics/test_average_precision.py
+++ b/tests/metrics/test_average_precision.py
@@ -5,6 +5,24 @@ import numpy as np
 from cubic.metrics.average_precision import compute_matches, average_precision
 
 
+def test_average_precision_supplied_matches_nonsequential_labels() -> None:
+    """Supplied matches with gapped label ids give correct FP/FN/AP.
+
+    ``.max()`` over-counted objects when label ids were non-sequential and the
+    sequential-label check (only in ``compute_matches``) was bypassed.
+    """
+    mask_true = np.array([[0, 5], [5, 9]], dtype=np.int32)  # 2 objects: 5, 9
+    mask_pred = mask_true.copy()
+    matches = {0.5: (np.array([5, 9]), np.array([5, 9]))}
+    ap, tp, fp, fn = average_precision(
+        mask_true, mask_pred, [0.5], matches_per_threshold=matches
+    )
+    assert tp[0] == 2
+    assert fp[0] == 0
+    assert fn[0] == 0
+    assert ap[0] == 1.0
+
+
 def test_average_precision_perfect_match() -> None:
     """Perfect overlap should yield perfect precision."""
     mask_true = np.array([[0, 1], [0, 2]], dtype=np.int32)

--- a/tests/metrics/test_feature.py
+++ b/tests/metrics/test_feature.py
@@ -1,0 +1,31 @@
+"""Tests for morphology feature-correlation helpers."""
+
+import numpy as np
+
+from cubic.metrics.feature import get_true_features
+
+
+def test_get_true_features_accepts_vector_property_names() -> None:
+    """A precomputed dict with expanded columns matches base feature names.
+
+    ``regionprops_table`` expands vector properties into ``centroid-0`` /
+    ``centroid-1`` columns. Requesting ``features=["centroid"]`` must not raise:
+    the validation compares base names, not expanded column names.
+    """
+    gt_feature_dict = {
+        "label": np.array([1, 2]),
+        "area": np.array([10.0, 20.0]),
+        "centroid-0": np.array([1.0, 5.0]),
+        "centroid-1": np.array([2.0, 6.0]),
+    }
+
+    labels, features_array, names = get_true_features(
+        None,
+        features=["centroid", "area"],
+        gt_feature_dict=gt_feature_dict,
+    )
+
+    np.testing.assert_array_equal(labels, [1, 2])
+    # numeric columns: area, centroid-0, centroid-1 (sorted) -> 3 columns
+    assert features_array.shape == (2, 3)
+    assert names == ["centroid", "area"]

--- a/tests/preprocessing/test_deconvolution.py
+++ b/tests/preprocessing/test_deconvolution.py
@@ -1,8 +1,49 @@
 """Tests for Richardson-Lucy deconvolution wrappers."""
 
 import numpy as np
+import pytest
 
-from cubic.preprocessing.deconvolution import richardson_lucy_iter
+from cubic.preprocessing.deconvolution import (
+    richardson_lucy_iter,
+    richardson_lucy_skimage,
+)
+from cubic.preprocessing.richardson_lucy_xp import richardson_lucy_xp
+
+
+def test_richardson_lucy_skimage_observer_matches_single_call() -> None:
+    """The observer path returns the same result as the no-observer call.
+
+    Previously it looped ``num_iter=1`` on the previous output, which re-clips
+    every iteration and feeds the deconvolution back as the image, diverging
+    from a single ``num_iter=n`` call.
+    """
+    rng = np.random.default_rng(0)
+    image = rng.random((16, 16)).astype(np.float64)
+    psf = np.zeros((3, 3), dtype=np.float64)
+    psf[1, 1] = 1.0
+
+    snapshots: list[np.ndarray] = []
+    out_obs = richardson_lucy_skimage(
+        image, psf, n_iter=4, observer_fn=lambda est, i: snapshots.append(est.copy())
+    )
+    out_single = richardson_lucy_skimage(image, psf, n_iter=4)
+
+    assert len(snapshots) == 4
+    assert np.allclose(out_obs, out_single)
+    assert np.allclose(snapshots[-1], out_single)
+
+
+@pytest.mark.parametrize("implementation", ["xp", "skimage"])
+def test_decon_iter_2d_input(implementation: str) -> None:
+    """2-D images run through the deconvolution wrappers (rank-agnostic slice)."""
+    image = np.zeros((8, 8), dtype=np.float32)
+    image[4, 4] = 1.0
+    psf = np.ones((3, 3), dtype=np.float32) / 9.0
+    out = richardson_lucy_iter(
+        image, psf, n_iter=2, implementation=implementation, pad_size_z=0
+    )
+    assert out.shape == image.shape
+    assert np.all(np.isfinite(out))
 
 
 def test_richardson_lucy_iter() -> None:
@@ -14,3 +55,20 @@ def test_richardson_lucy_iter() -> None:
     res_sk = richardson_lucy_iter(image, psf, n_iter=1, implementation="skimage")
     assert res_xp.shape == image.shape
     assert res_sk.shape == image.shape
+
+
+@pytest.mark.parametrize("noncirc", [False, True])
+def test_richardson_lucy_xp_psf_smaller_than_image_odd_diff(noncirc: bool) -> None:
+    """A smaller PSF with odd size differences pads to the image without error.
+
+    The previous ``pad_image_to_shape`` padded symmetrically by ``diff // 2`` on
+    both sides, falling one element short for odd diffs and tripping its assert.
+    """
+    rng = np.random.default_rng(0)
+    image = rng.random((10, 32, 32)).astype(np.float64)
+    psf = np.zeros((5, 7, 7), dtype=np.float64)
+    psf[2, 3, 3] = 1.0  # centered delta -> output approximates the input
+
+    out = richardson_lucy_xp(image, psf, n_iter=3, noncirc=noncirc)
+    assert out.shape == image.shape
+    assert np.all(np.isfinite(out))

--- a/tests/segmentation/test_clear_border.py
+++ b/tests/segmentation/test_clear_border.py
@@ -1,6 +1,7 @@
 """Tests for border-clearing segmentation helper."""
 
 import numpy as np
+import pytest
 
 from cubic.segmentation._clear_border import clear_border
 
@@ -35,3 +36,11 @@ def test_clear_border_all_border_objects() -> None:
     labels = np.array([[1, 0], [0, 2]], dtype=int)
     result = clear_border(labels.copy())
     assert np.all(result == 0)
+
+
+def test_clear_border_mask_shape_mismatch_raises_valueerror() -> None:
+    """A mismatched mask raises ValueError (previously raised TypeError)."""
+    labels = np.zeros((4, 4), dtype=int)
+    bad_mask = np.ones((3, 3), dtype=bool)
+    with pytest.raises(ValueError, match="same shape"):
+        clear_border(labels, mask=bad_mask)

--- a/tests/segmentation/test_segment_utils.py
+++ b/tests/segmentation/test_segment_utils.py
@@ -1,0 +1,37 @@
+"""Tests for segmentation post-processing utilities."""
+
+import numpy as np
+
+from cubic.segmentation.segment_utils import remove_touching_objects
+
+
+def test_remove_touching_objects_keeps_isolated_high_labels() -> None:
+    """Labels above the legacy border_value are not misclassified as touching.
+
+    Two adjacent objects (150, 151) must be removed; an isolated object (200)
+    must be kept. The previous additive-offset implementation treated every
+    label id > border_value (=100) as touching and deleted everything.
+    """
+    volume = np.zeros((3, 9, 9), dtype=np.int32)
+    volume[1, 1:3, 1:3] = 150  # touches 151
+    volume[1, 3:5, 1:3] = 151  # touches 150
+    volume[1, 7:9, 7:9] = 200  # isolated
+
+    result = remove_touching_objects(volume.copy())
+    remaining = set(np.unique(result).tolist())
+
+    assert 200 in remaining
+    assert 150 not in remaining
+    assert 151 not in remaining
+
+
+def test_remove_touching_objects_keeps_all_isolated() -> None:
+    """All non-touching objects survive regardless of label magnitude."""
+    volume = np.zeros((3, 9, 9), dtype=np.int32)
+    volume[1, 1:3, 1:3] = 105
+    volume[1, 6:8, 6:8] = 250
+
+    result = remove_touching_objects(volume.copy())
+    remaining = set(np.unique(result).tolist())
+
+    assert remaining == {0, 105, 250}

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -8,8 +8,20 @@ from cubic.cuda import (
     asnumpy,
     to_device,
     get_device,
+    is_gpu_array,
     check_same_device,
 )
+
+
+def test_is_gpu_array_classification(gpu_available: bool) -> None:
+    """``is_gpu_array`` is True only for GPU arrays, not NumPy or scalars."""
+    assert is_gpu_array(np.ones((2, 2))) is False
+    assert is_gpu_array(5) is False
+    assert is_gpu_array("not an array") is False
+    assert is_gpu_array([1, 2, 3]) is False
+
+    if gpu_available:
+        assert is_gpu_array(ascupy(np.ones((2, 2)))) is True
 
 
 @pytest.mark.parametrize("device", ["CPU", "GPU"])

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -5,13 +5,37 @@ import pytest
 
 from cubic.cuda import ascupy, asnumpy
 from cubic.image_utils import (
+    crop_bl,
+    crop_br,
+    crop_tl,
+    crop_tr,
+    crop_center,
     rotate_image,
     binomial_split,
     pad_image_to_cube,
     checkerboard_split,
+    pad_image_to_shape,
     reverse_checkerboard_split,
     select_max_contrast_slices,
 )
+
+
+def test_crop_corner_all_four_corners() -> None:
+    """Each corner crop selects the right 2x2 block (br previously returned all)."""
+    img = np.arange(1, 17).reshape(4, 4)
+    np.testing.assert_array_equal(crop_tl(img, 2, axes=[0, 1]), [[1, 2], [5, 6]])
+    np.testing.assert_array_equal(crop_tr(img, 2, axes=[0, 1]), [[3, 4], [7, 8]])
+    np.testing.assert_array_equal(crop_bl(img, 2, axes=[0, 1]), [[9, 10], [13, 14]])
+    np.testing.assert_array_equal(crop_br(img, 2, axes=[0, 1]), [[11, 12], [15, 16]])
+
+
+def test_pad_image_to_shape_odd_difference_round_trips() -> None:
+    """Odd size differences reach the exact target and invert via crop_center."""
+    img = np.arange(5 * 7 * 7, dtype=np.float64).reshape(5, 7, 7)
+    target = (10, 8, 8)  # odd diff on axis 0 (5), odd on axes 1, 2 (1)
+    padded = pad_image_to_shape(img, target, mode="constant")
+    assert padded.shape == target
+    np.testing.assert_array_equal(crop_center(padded, img.shape), img)
 
 
 def test_pad_image_to_cube() -> None:

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -1,0 +1,22 @@
+"""Tests for plotting helpers."""
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless backend for tests
+
+import numpy as np  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+
+from cubic.plot_utils import show_image_error  # noqa: E402
+
+
+def test_show_image_error_symmetric_clim() -> None:
+    """The diverging error map is centered on zero (symmetric color limits)."""
+    img = np.zeros((4, 4), dtype=np.float32)
+    fig = show_image_error(img, bit_depth=14)
+    try:
+        vmin, vmax = fig.axes[0].images[0].get_clim()
+        assert vmin == -vmax
+        assert vmax == 2**14 - 1
+    finally:
+        plt.close(fig)

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -1,6 +1,10 @@
 """Tests for plotting helpers."""
 
-import matplotlib
+import pytest
+
+pytest.importorskip("matplotlib")  # optional [plot] extra; skip when absent
+
+import matplotlib  # noqa: E402
 
 matplotlib.use("Agg")  # headless backend for tests
 

--- a/tests/test_scipy_proxy.py
+++ b/tests/test_scipy_proxy.py
@@ -4,7 +4,31 @@ import numpy as np
 import pytest
 
 import cubic.scipy as mc_scipy
-from cubic.cuda import ascupy, asnumpy
+from cubic.cuda import ascupy, asnumpy, get_device
+
+
+@pytest.mark.parametrize("use_gpu", [False, True])
+def test_dispatch_on_array_passed_by_keyword(
+    use_gpu: bool, gpu_available: bool
+) -> None:
+    """A GPU array under a non-``input`` keyword routes to the GPU backend.
+
+    ``fftconvolve(in1=..., in2=...)`` has no ``input`` argument, so the old
+    first-arg-only detection saw no device, routed to CPU SciPy, and crashed
+    on the raw CuPy arrays. Detection now scans every argument.
+    """
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    b = np.array([0.5, 0.5])
+    cpu_res = mc_scipy.signal.fftconvolve(in1=a, in2=b)
+
+    if use_gpu:
+        if not gpu_available:
+            pytest.skip("GPU not available")
+        gpu_res = mc_scipy.signal.fftconvolve(in1=ascupy(a), in2=ascupy(b))
+        assert get_device(gpu_res) == "GPU"
+        assert np.allclose(asnumpy(gpu_res), cpu_res)
+    else:
+        assert np.allclose(mc_scipy.signal.fftconvolve(in1=a, in2=b), cpu_res)
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])

--- a/tests/test_scipy_proxy.py
+++ b/tests/test_scipy_proxy.py
@@ -1,7 +1,10 @@
 """Tests for the SciPy proxy implementation."""
 
+from typing import Any
+
 import numpy as np
 import pytest
+from scipy import signal as sp_signal
 
 import cubic.scipy as mc_scipy
 from cubic.cuda import ascupy, asnumpy, get_device
@@ -45,3 +48,35 @@ def test_ndimage_laplace_cpu_vs_gpu(use_gpu: bool, gpu_available: bool) -> None:
     else:
         gpu_res = mc_scipy.ndimage.laplace(a)
         assert np.allclose(cpu_res, gpu_res)
+
+
+def test_gpu_fallback_to_cpu_when_cupyx_unavailable(
+    monkeypatch: pytest.MonkeyPatch, gpu_available: bool
+) -> None:
+    """A missing ``cupyx.scipy`` backend computes on CPU and returns to the GPU.
+
+    When the ``cupyx.scipy`` import fails for a GPU input, the proxy warns,
+    coerces the arguments to host, runs ``scipy``, then moves the result back
+    to the GPU so the caller still gets a device-consistent array.
+    """
+    if not gpu_available:
+        pytest.skip("GPU not available")
+
+    real_import_module = mc_scipy.import_module
+
+    def fake_import_module(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name.startswith("cupyx"):
+            raise ModuleNotFoundError(f"simulated missing module: {name}")
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(mc_scipy, "import_module", fake_import_module)
+
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    b = np.array([0.5, 0.5])
+    cpu_res = sp_signal.fftconvolve(a, b)
+
+    with pytest.warns(UserWarning, match="falling back to CPU"):
+        gpu_res = mc_scipy.signal.fftconvolve(ascupy(a), ascupy(b))
+
+    assert get_device(gpu_res) == "GPU"
+    assert np.allclose(asnumpy(gpu_res), cpu_res)

--- a/tests/test_skimage_proxy.py
+++ b/tests/test_skimage_proxy.py
@@ -4,7 +4,35 @@ import numpy as np
 import pytest
 
 import cubic.skimage as mc_skimage
-from cubic.cuda import CUDAManager, ascupy, asnumpy
+from cubic.cuda import CUDAManager, ascupy, asnumpy, get_device
+
+
+@pytest.mark.parametrize("use_gpu", [False, True])
+def test_dispatch_on_array_passed_by_keyword(
+    use_gpu: bool, gpu_available: bool
+) -> None:
+    """A GPU array under a non-``image`` keyword routes to the cuCIM backend.
+
+    ``rescale(image=..., scale=...)`` works either way, but detection now
+    scans all arguments so a GPU array under any keyword reaches the GPU
+    implementation instead of crashing a host scikit-image call.
+    """
+    img = np.random.random((8, 8)).astype(np.float32)
+    cpu_res = mc_skimage.transform.rescale(image=img, scale=0.5, preserve_range=True)
+
+    if use_gpu:
+        if not gpu_available:
+            pytest.skip("GPU not available")
+        gpu_res = mc_skimage.transform.rescale(
+            image=ascupy(img), scale=0.5, preserve_range=True
+        )
+        assert get_device(gpu_res) == "GPU"
+        assert np.allclose(asnumpy(gpu_res), cpu_res, atol=1e-5)
+    else:
+        assert np.allclose(
+            mc_skimage.transform.rescale(image=img, scale=0.5, preserve_range=True),
+            cpu_res,
+        )
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])

--- a/tests/test_skimage_proxy.py
+++ b/tests/test_skimage_proxy.py
@@ -13,26 +13,24 @@ def test_dispatch_on_array_passed_by_keyword(
 ) -> None:
     """A GPU array under a non-``image`` keyword routes to the cuCIM backend.
 
-    ``rescale(image=..., scale=...)`` works either way, but detection now
-    scans all arguments so a GPU array under any keyword reaches the GPU
-    implementation instead of crashing a host scikit-image call.
+    ``measure.label(label_image=...)`` passes the array under ``label_image``,
+    a keyword the old first-arg/``image``-only detection never inspected — so a
+    GPU array there routed to host scikit-image and crashed. Detection now
+    scans every argument.
     """
-    img = np.random.random((8, 8)).astype(np.float32)
-    cpu_res = mc_skimage.transform.rescale(image=img, scale=0.5, preserve_range=True)
+    mask = np.zeros((8, 8), dtype=np.uint8)
+    mask[1:3, 1:3] = 1
+    mask[5:7, 5:7] = 1
+    cpu_res = mc_skimage.measure.label(label_image=mask)
 
     if use_gpu:
         if not gpu_available:
             pytest.skip("GPU not available")
-        gpu_res = mc_skimage.transform.rescale(
-            image=ascupy(img), scale=0.5, preserve_range=True
-        )
+        gpu_res = mc_skimage.measure.label(label_image=ascupy(mask))
         assert get_device(gpu_res) == "GPU"
-        assert np.allclose(asnumpy(gpu_res), cpu_res, atol=1e-5)
+        assert np.array_equal(asnumpy(gpu_res), cpu_res)
     else:
-        assert np.allclose(
-            mc_skimage.transform.rescale(image=img, scale=0.5, preserve_range=True),
-            cpu_res,
-        )
+        assert np.array_equal(mc_skimage.measure.label(label_image=mask), cpu_res)
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])


### PR DESCRIPTION
## Summary

A review-driven sweep of correctness bugs across the codebase, each fix paired with a regression test. 10 atomic commits, grouped by concept.

Full suite passes on the **A40 GPU** (`uv run pytest`: 354 passed, 0 skipped — every GPU-gated test exercised), plus `ruff check`/`ruff format` and `mypy` clean (pre-commit hooks ran on each commit).

## Fixes

- **image_utils** — `crop_corner("br")` returned the whole image (reachable via `crop_br` in the FRC local-resolution sweep); `pad_image_to_shape` fell one short on odd size differences and tripped its assert (broke `richardson_lucy_xp` with mismatched PSFs). Now both correct and `crop_center`-consistent.
- **preprocessing** — `decon_*` 3D-only slicing (`, :, :`) raised on 2D; made rank-agnostic. `richardson_lucy_skimage` observer path re-clipped each iteration and fed the deconvolution back as the image — now recomputes per depth so snapshots are true *i*-iteration results and the final matches the no-observer call.
- **segmentation** — `remove_touching_objects` used an additive `border_value=100` offset that misclassified any label id > 100 as touching, silently deleting non-touching objects (Cellpose emits hundreds of labels). Now reads neighbours directly. `clear_border` raised a tuple (`TypeError`) instead of the intended `ValueError`.
- **cuda / proxies** — SciPy & scikit-image proxies detected device from only the first arg; a GPU array under any other keyword routed to CPU and crashed. Added `is_gpu_array`, scan all args, coerce on the CPU branch.
- **metrics/ms_ssim** — kernel width now tracks `kernel_size` (was desynced from the Gaussian radius, leaking `cval=0` for small kernels); `(N,H,W)` now reduces per image (was pooling across the batch). 2D unchanged.
- **metrics/average_precision** — count distinct labels instead of `.max()` so supplied non-sequential matches give correct FP/FN/AP.
- **metrics/feature** — `get_true_features` matched base feature names against expanded column names, raising spuriously for vector properties.
- **metrics/spectral/radial** — `use_max_nyquist` was ignored for index units, compressing the XY-sector DCR/FSC curve on anisotropic shapes (default `dcr_resolution` path).
- **feature/mesh** — `extract_features` included background label 0; now excluded, matching `voxel.regionprops`.
- **plot_utils** — `show_image_error` color limits were asymmetric; now centered on zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix a range of correctness issues across image utilities, deconvolution wrappers, GPU-aware SciPy/skimage proxies, and evaluation metrics, adding targeted regression tests for each case.

Bug Fixes:
- Correct crop_corner corner selection so all four directional helpers return the intended image region and align padding with crop_center in pad_image_to_shape, including odd size differences.
- Make Richardson–Lucy deconvolution wrappers rank-agnostic for 2D/3D inputs and fix the skimage observer mode so per-iteration snapshots and the final result match the no-observer call.
- Fix remove_touching_objects to detect touching labels via direct neighborhood inspection instead of a border offset that wrongly removed high-id labels, and ensure clear_border raises ValueError on mask shape mismatch.
- Align MS-SSIM Gaussian kernel width with kernel_size and compute per-image reductions for batched inputs, matching torchmetrics’ behavior for default and non-default kernels.
- Compute average precision false positives and false negatives from distinct label counts instead of max label id so non-sequential labels with supplied matches are handled correctly.
- Allow get_true_features to accept vector morphology properties by validating against base feature names instead of expanded column names.
- Honor use_max_nyquist for index-unit radial bin edges so anisotropic shapes extend to the maximum axis Nyquist frequency.
- Exclude background label 0 from mesh-based feature extraction to match voxel.regionprops semantics.
- Center show_image_error’s color limits symmetrically around zero based on bit depth.

Enhancements:
- Introduce a shared GPU array detector and update SciPy and scikit-image proxies to inspect all arguments, correctly routing GPU arrays passed under any parameter name and safely coercing stray GPU arrays on the CPU path.

Tests:
- Add regression tests for corner cropping and odd-difference padding round trips, deconvolution observers and 2D inputs, GPU dispatch in SciPy and skimage proxies, MS-SSIM batch behavior and kernel-size handling, non-sequential-label average precision, vector feature handling, radial edge Nyquist behavior, mesh feature background exclusion, clear_border error typing, CUDA GPU-array detection, and symmetric error-map color limits.