### PR TITLE
Support all Cellpose v4 models (SAM + DINO) in GPU-resident segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Optional extras from `pyproject.toml` enable additional functionality:
 pip install '.[mesh]'
 # segmentation via Cellpose (SAM models: cpsam, cpsam_v2)
 pip install '.[cellpose]'
-# also enable the Cellpose DINO models (cpdino, cpdino-vitb)
-pip install '.[cellpose-dino]'
+# the Cellpose DINO models (cpdino, cpdino-vitb) additionally require dinov3,
+# which is only published on GitHub:
+pip install 'git+https://github.com/facebookresearch/dinov3'
 # plotting helpers (matplotlib)
 pip install '.[plot]'
 # run the example notebooks (jupyter, pooch)

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ Optional extras from `pyproject.toml` enable additional functionality:
 ```bash
 # mesh feature extraction
 pip install '.[mesh]'
-# segmentation via Cellpose
+# segmentation via Cellpose (SAM models: cpsam, cpsam_v2)
 pip install '.[cellpose]'
+# also enable the Cellpose DINO models (cpdino, cpdino-vitb)
+pip install '.[cellpose-dino]'
 # plotting helpers (matplotlib)
 pip install '.[plot]'
 # run the example notebooks (jupyter, pooch)

--- a/cubic/__init__.py
+++ b/cubic/__init__.py
@@ -1,3 +1,3 @@
 """Morphomeric analysis of 3D cell images."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0a1"

--- a/cubic/segmentation/__init__.py
+++ b/cubic/segmentation/__init__.py
@@ -10,12 +10,13 @@ from .segment_utils import (
     remove_small_objects,
     remove_touching_objects,
 )
-from .cellpose_sam_gpu import segment_cpsam
+from .cellpose_sam_gpu import segment_cpsam, segment_cellpose
 
 __all__ = [
     "cellpose_eval",
     "cellpose_segment",
     "segment_cpsam",
+    "segment_cellpose",
     "downscale_and_filter",
     "remove_touching_objects",
     "remove_small_objects",

--- a/cubic/segmentation/cellpose.py
+++ b/cubic/segmentation/cellpose.py
@@ -30,12 +30,14 @@ def cellpose_eval(
     flow_threshold: float = 0.4,
     cellprob_threshold: float = 0.0,
 ) -> np.ndarray:
-    """Run a pretrained Cellpose-SAM (v4) model and return masks.
+    """Run a pretrained Cellpose v4 model and return masks.
 
     Cellpose 4 removed the ``Cellpose`` class and the ``model_type``/``omni``/
     ``channels`` arguments; this uses ``CellposeModel`` with a
-    ``pretrained_model`` (default the Cellpose-SAM weights ``"cpsam"``) and
-    ``channel_axis`` for multi-channel inputs.
+    ``pretrained_model`` and ``channel_axis`` for multi-channel inputs. Any v4
+    model name is accepted -- the SAM backbone (``"cpsam"`` (default),
+    ``"cpsam_v2"``) or the DINOv3 backbones (``"cpdino"``, ``"cpdino-vitb"``) --
+    or a path to a custom model.
     """
     if not _CELLPOSE_AVAILABLE:
         raise ImportError(
@@ -69,7 +71,7 @@ def cellpose_segment(
     border_value: int = 100,
     min_size: int = 500,
 ) -> np.ndarray:
-    """Preprocess image, run Cellpose-SAM and postprocessing."""
+    """Preprocess image, run a Cellpose v4 model (SAM or DINO) and postprocess."""
     if not _CELLPOSE_AVAILABLE:
         raise ImportError(
             "Cellpose is required for this function, but not available. "

--- a/cubic/segmentation/cellpose_sam_gpu.py
+++ b/cubic/segmentation/cellpose_sam_gpu.py
@@ -393,16 +393,33 @@ def run_3D_gpu(
     return yf, style
 
 
+def _resolve_bsize(backbone: str, bsize: int | None) -> int:
+    """Resolve the tile size for a backbone, mirroring ``CellposeModel``.
+
+    The SAM backbone's position embeddings are fixed to a 256-pixel tile, so it
+    rejects any other ``bsize``; the DINO backbones default to 384 but accept
+    other sizes. This is the single source of truth for the backbone→tile-size
+    relationship.
+    """
+    if backbone == "sam_vitl":
+        if bsize not in (None, 256):
+            raise ValueError(
+                "bsize != 256 is not supported for the SAM backbone "
+                "(cpsam/cpsam_v2), please set bsize to 256."
+            )
+        return 256
+    return 384 if bsize is None else bsize
+
+
 def _run_net_gpu(
     net: Any,
     x: Any,
-    backbone: str = "sam_vitl",
     rescale: float = 1.0,
     resample: bool = True,
     augment: bool = False,
     batch_size: int = 8,
     tile_overlap: float = 0.1,
-    bsize: int | None = None,
+    bsize: int = 256,
     anisotropy: float | None = 1.0,
     do_3D: bool = False,
 ) -> tuple[Any, Any, Any]:
@@ -410,10 +427,9 @@ def _run_net_gpu(
 
     Owns the dP/cellprob split, the flow transpose, the 3D channel reassembly
     and the resample/anisotropy resize that ``run_net``/``run_3D`` do not.
+    ``bsize`` is the concrete tile size (see :func:`_resolve_bsize`).
     """
     shape = x.shape
-    if bsize is None:
-        bsize = 256 if backbone == "sam_vitl" else 384
 
     if do_3D:
         Lz, Ly, Lx = shape[:-1]
@@ -824,14 +840,7 @@ def segment_cellpose(
     """
     _require_cellpose()
     _check_gpu_precondition(model)
-
-    # mirror cellpose: the SAM backbone's position embeddings are fixed to a
-    # 256-pixel tile, so only the DINO backbones may change bsize.
-    if bsize is not None and model.backbone == "sam_vitl" and bsize != 256:
-        raise ValueError(
-            "bsize != 256 is not supported for the SAM backbone (cpsam/cpsam_v2), "
-            "please set bsize to 256."
-        )
+    bsize = _resolve_bsize(model.backbone, bsize)
 
     # list / 5D-array of images: process one at a time (mirror CellposeModel.eval)
     if isinstance(x, list) or (hasattr(x, "ndim") and x.squeeze().ndim == 5):
@@ -913,7 +922,6 @@ def segment_cellpose(
     dP, cellprob, styles = _run_net_gpu(
         model.net,
         x,
-        backbone=model.backbone,
         rescale=rescale,
         resample=resample,
         augment=augment,

--- a/cubic/segmentation/cellpose_sam_gpu.py
+++ b/cubic/segmentation/cellpose_sam_gpu.py
@@ -409,7 +409,11 @@ def _resolve_bsize(backbone: str, bsize: int | None) -> int:
                 "(cpsam/cpsam_v2), please set bsize to 256."
             )
         return 256
-    return 384 if bsize is None else bsize
+    if bsize is None:
+        return 384
+    if bsize <= 0:
+        raise ValueError(f"bsize must be a positive integer, got {bsize}.")
+    return bsize
 
 
 def _run_net_gpu(

--- a/cubic/segmentation/cellpose_sam_gpu.py
+++ b/cubic/segmentation/cellpose_sam_gpu.py
@@ -50,8 +50,9 @@ except ImportError:  # pragma: no cover - exercised in no-cellpose envs
 def _require_cellpose() -> None:
     if not _CELLPOSE_AVAILABLE:
         raise ImportError(
-            "cellpose>=4 (SAM) is required for the GPU-resident path. "
-            "Install with `pip install cubic[cellpose]`."
+            "cellpose>=4 (SAM or DINO) is required for the GPU-resident path. "
+            "Install with `pip install cubic[cellpose]` (DINO backbones also "
+            "need `dinov3`; see the README)."
         )
 
 

--- a/cubic/segmentation/cellpose_sam_gpu.py
+++ b/cubic/segmentation/cellpose_sam_gpu.py
@@ -1,9 +1,14 @@
-"""GPU-resident Cellpose-SAM inference: preprocessing, tiling and network forward.
+"""GPU-resident Cellpose v4 inference: preprocessing, tiling and network forward.
+
+Supports every Cellpose v4 model -- the SAM backbone (``cpsam``, ``cpsam_v2``)
+and the DINOv3 backbones (``cpdino``, ``cpdino-vitb``). The backbones differ only
+in the default tile size (256 for ``sam_vitl``, 384 for ``dino_*``); both emit the
+same ``(flow, style)`` forward contract, so the rest of the path is shared.
 
 This module mirrors ``cellpose.transforms`` / ``cellpose.core`` but keeps every
 array on the GPU as a CuPy array, bridging to torch *zero-copy* only for the
 network forward. The input image is uploaded to the device exactly once
-(:func:`segment_cpsam`) and only the final integer mask returns to the
+(:func:`segment_cellpose`) and only the final integer mask returns to the
 host (mask computation lives in :mod:`cubic.segmentation.cellpose_dynamics`).
 
 cellpose itself is never modified. Heavy CPU dependencies are replaced with
@@ -17,6 +22,7 @@ the building-block transforms remain device-agnostic and run on NumPy too.
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import numpy as np
@@ -323,8 +329,10 @@ def run_net_gpu(
         ya = None
         for j in range(0, IMGa.shape[0], batch_size):
             bslc = slice(j, min(j + batch_size, IMGa.shape[0]))
-            # CPSAM emits zero style vectors (matching stock eval), so styles
-            # stay the allocated zeros; only the flow output is accumulated.
+            # the network's second output is a vestigial style vector (zeros for
+            # CPSAM, random noise for CPDINO) that stock eval keeps only for CP3
+            # back-compat and never feeds into the masks; we discard it and keep
+            # the allocated zeros, accumulating only the flow output.
             ya0, _style0 = _forward_gpu(net, IMGa[bslc])
             if ya is None:
                 nout = ya0.shape[1]
@@ -742,26 +750,27 @@ def normalize_img_gpu(img: Any, *, device: Any = None, **params: Any) -> Any:
 # orchestrator
 # --------------------------------------------------------------------------- #
 def _check_gpu_precondition(model: Any) -> None:
-    """GPU-only contract: require CUDA + cupy + a SAM (v4) model on cuda."""
+    """GPU-only contract: require CUDA + cupy + a Cellpose v4 model on cuda."""
     if CUDAManager().get_cp() is None:
         raise RuntimeError(
-            "segment_cpsam requires cupy + a CUDA GPU; use CellposeModel.eval for CPU."
+            "segment_cellpose requires cupy + a CUDA GPU; "
+            "use CellposeModel.eval for CPU."
         )
     if getattr(model, "device", None) is None or model.device.type != "cuda":
         raise RuntimeError(
-            "segment_cpsam requires a model on a CUDA device "
+            "segment_cellpose requires a model on a CUDA device "
             f"(got device={getattr(model, 'device', None)})."
         )
     if not hasattr(model, "backbone") or not hasattr(
         getattr(model, "net", None), "dtype"
     ):
         raise RuntimeError(
-            "segment_cpsam requires cellpose>=4 (SAM): "
+            "segment_cellpose requires cellpose>=4 (SAM or DINO): "
             "model.backbone / model.net.dtype not found."
         )
 
 
-def segment_cpsam(
+def segment_cellpose(
     model: Any,
     x: Any,
     *,
@@ -782,20 +791,27 @@ def segment_cpsam(
     niter: int | None = None,
     augment: bool = False,
     tile_overlap: float = 0.1,
+    bsize: int | None = None,
     download: bool = False,
 ) -> tuple[Any, list, Any]:
-    """Segment an image with Cellpose-SAM, GPU-resident (2D / 3D / stitch).
+    """Segment an image with Cellpose v4 (SAM or DINO), GPU-resident.
 
-    This is cubic's recommended Cellpose-SAM segmentation entry point: the
-    input is uploaded to the GPU once and only the final integer mask returns
-    to the host (default). It mirrors ``CellposeModel.eval`` but keeps the flow
-    field on the device, replacing the CPU pre/post-processing with cubic's
-    device-agnostic wrappers.
+    This is cubic's recommended Cellpose v4 segmentation entry point, for both
+    the SAM backbone (``cpsam``, ``cpsam_v2``) and the DINOv3 backbones
+    (``cpdino``, ``cpdino-vitb``): the input is uploaded to the GPU once and only
+    the final integer mask returns to the host (default). It mirrors
+    ``CellposeModel.eval`` but keeps the flow field on the device, replacing the
+    CPU pre/post-processing with cubic's device-agnostic wrappers.
 
     Args:
-        model: A pre-built ``cellpose.models.CellposeModel`` (v4/SAM) on CUDA.
+        model: A pre-built ``cellpose.models.CellposeModel`` (v4, SAM or DINO)
+            on CUDA.
         x: A single image (2D/3D/4D), or a list / 5D array of images (processed
             one at a time, each uploaded to the GPU once; returns lists).
+        bsize: Tile block size. If ``None`` (default), uses 256 for the SAM
+            backbone and 384 for the DINO backbones (matching ``CellposeModel``).
+            A non-256 value is rejected for the SAM backbone (mirrors cellpose);
+            the DINO backbones accept other sizes.
         download: If ``False`` (default), return ``masks`` as NumPy (the single
             device→host transfer) and ``[None, dP, cellprob]`` + ``styles`` as
             CuPy (GPU-resident). If ``True``, also move ``dP``/``cellprob``/
@@ -809,6 +825,14 @@ def segment_cpsam(
     _require_cellpose()
     _check_gpu_precondition(model)
 
+    # mirror cellpose: the SAM backbone's position embeddings are fixed to a
+    # 256-pixel tile, so only the DINO backbones may change bsize.
+    if bsize is not None and model.backbone == "sam_vitl" and bsize != 256:
+        raise ValueError(
+            "bsize != 256 is not supported for the SAM backbone (cpsam/cpsam_v2), "
+            "please set bsize to 256."
+        )
+
     # list / 5D-array of images: process one at a time (mirror CellposeModel.eval)
     if isinstance(x, list) or (hasattr(x, "ndim") and x.squeeze().ndim == 5):
         nimg = len(x)
@@ -817,7 +841,7 @@ def segment_cpsam(
         )
         masks_out, flows_out, styles_out = [], [], []
         for i in range(nimg):
-            out = segment_cpsam(
+            out = segment_cellpose(
                 model,
                 x[i],
                 batch_size=batch_size,
@@ -837,6 +861,7 @@ def segment_cpsam(
                 niter=niter,
                 augment=augment,
                 tile_overlap=tile_overlap,
+                bsize=bsize,
                 download=download,
             )
             masks_out.append(out[0])
@@ -894,6 +919,7 @@ def segment_cpsam(
         augment=augment,
         batch_size=batch_size,
         tile_overlap=tile_overlap,
+        bsize=bsize,
         do_3D=do_3D,
         anisotropy=anisotropy,
     )
@@ -939,3 +965,21 @@ def segment_cpsam(
             asnumpy(styles),
         )
     return asnumpy(masks), [None, dP, cellprob], styles
+
+
+def segment_cpsam(*args: Any, **kwargs: Any) -> tuple[Any, list, Any]:
+    """Forward to :func:`segment_cellpose` (deprecated alias).
+
+    .. deprecated:: 0.8
+        Renamed to :func:`segment_cellpose` now that the GPU-resident path also
+        supports the DINO backbones (``cpdino``, ``cpdino-vitb``), not just SAM.
+        ``segment_cpsam`` forwards to :func:`segment_cellpose` and will be
+        removed in a future release.
+    """
+    warnings.warn(
+        "segment_cpsam is deprecated; use segment_cellpose instead "
+        "(the GPU-resident path now supports the DINO backbones too).",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return segment_cellpose(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,6 @@ cellpose = [
     "cellpose>=4.2.0",
     "torch",
 ]
-cellpose-dino = [
-    "cubic[cellpose]",
-    "cellpose[dino]>=4.2.0",
-]
 mesh = [
     "trimesh>=3.3.0",
 ]
@@ -63,7 +59,6 @@ dev = [
 ]
 all = [
     "cubic[cellpose]",
-    "cubic[cellpose-dino]",
     "cubic[mesh]",
     "cubic[plot]",
     "cubic[examples]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,12 @@ Repository = "https://github.com/alxndrkalinin/cubic"
 
 [project.optional-dependencies]
 cellpose = [
-    "cellpose>=4.0",
+    "cellpose>=4.2.0",
     "torch",
+]
+cellpose-dino = [
+    "cubic[cellpose]",
+    "cellpose[dino]>=4.2.0",
 ]
 mesh = [
     "trimesh>=3.3.0",
@@ -59,6 +63,7 @@ dev = [
 ]
 all = [
     "cubic[cellpose]",
+    "cubic[cellpose-dino]",
     "cubic[mesh]",
     "cubic[plot]",
     "cubic[examples]",

--- a/tests/segmentation/test_cellpose_sam_gpu.py
+++ b/tests/segmentation/test_cellpose_sam_gpu.py
@@ -5,6 +5,7 @@ suite collects on CPU/no-GPU CI; GPU/cellpose-dependent tests skip cleanly.
 """
 
 from typing import Any
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -16,6 +17,36 @@ def _require_cellpose_v4() -> None:
 
     if not hasattr(models, "CellposeModel"):  # pragma: no cover
         pytest.skip("requires cellpose>=4 (SAM)")
+
+
+@pytest.fixture(scope="module")
+def cellpose_model() -> Any:
+    """Return a factory caching one ``CellposeModel`` per backbone for the module.
+
+    ``eval`` / ``segment_cellpose`` are read-only inference, so a single instance
+    per backbone is shared across the module's tests instead of reloading the
+    weights for every test (``cpsam`` alone is used by most parity tests). Lazy:
+    nothing is built until a test that cleared its GPU/cellpose guards asks for a
+    model, so no-GPU/no-cellpose runs never construct one.
+    """
+    cache: dict[str, Any] = {}
+
+    def _get(pretrained_model: str) -> Any:
+        from cellpose.models import CellposeModel
+
+        if pretrained_model not in cache:
+            cache[pretrained_model] = CellposeModel(
+                gpu=True, pretrained_model=pretrained_model
+            )
+        return cache[pretrained_model]
+
+    yield _get
+
+    if cache:  # models were built -> a CUDA GPU + torch are present
+        cache.clear()
+        import torch
+
+        torch.cuda.empty_cache()
 
 
 def _disks(h: int = 224, w: int = 224, centers=None, r: int = 15) -> np.ndarray:
@@ -112,14 +143,15 @@ def test_resident_rejects_non_cuda_model() -> None:
         g.segment_cellpose(_Model(), np.zeros((32, 32), np.float32))
 
 
-def test_sam_model_exposes_v4_api(gpu_available: bool) -> None:
+def test_sam_model_exposes_v4_api(
+    gpu_available: bool, cellpose_model: Callable[[str], Any]
+) -> None:
     """Fail loudly on a v3 env: SAM model must expose backbone + net.dtype."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
 
-    model = CellposeModel(gpu=True, pretrained_model="cpsam")
+    model = cellpose_model("cpsam")
     assert hasattr(model, "backbone")
     assert hasattr(model.net, "dtype")
     assert model.device.type == "cuda"
@@ -151,18 +183,18 @@ def test_building_blocks_run_on_cpu() -> None:
     assert isinstance(sharp, np.ndarray) and sharp.shape == x.shape
 
 
-def test_parity_2d_vs_stock(gpu_available: bool) -> None:
+def test_parity_2d_vs_stock(
+    gpu_available: bool, cellpose_model: Callable[[str], Any]
+) -> None:
     """Resident masks match stock CellposeModel.eval (AP >= 0.95 @ IoU 0.5)."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
-
     from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     img = _disks()
-    model = CellposeModel(gpu=True, pretrained_model="cpsam")
+    model = cellpose_model("cpsam")
     m_stock, _, _ = model.eval(img, diameter=None, do_3D=False)
     m_gpu, _, _ = segment_cellpose(model, img, do_3D=False, download=True)
 
@@ -174,19 +206,19 @@ def test_parity_2d_vs_stock(gpu_available: bool) -> None:
     )
 
 
-def test_parity_tile_norm_2d_vs_stock(gpu_available: bool) -> None:
+def test_parity_tile_norm_2d_vs_stock(
+    gpu_available: bool, cellpose_model: Callable[[str], Any]
+) -> None:
     """tile_norm_blocksize>0 (2D) matches stock eval (AP >= 0.95 @ IoU 0.5)."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
-
     from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     img = _disks()
     normalize = {"tile_norm_blocksize": 64}
-    model = CellposeModel(gpu=True, pretrained_model="cpsam")
+    model = cellpose_model("cpsam")
     m_stock, _, _ = model.eval(img, diameter=None, do_3D=False, normalize=normalize)
     m_gpu, _, _ = segment_cellpose(
         model, img, do_3D=False, normalize=normalize, download=True
@@ -200,19 +232,19 @@ def test_parity_tile_norm_2d_vs_stock(gpu_available: bool) -> None:
     )
 
 
-def test_parity_tile_norm_3d_vs_stock(gpu_available: bool) -> None:
+def test_parity_tile_norm_3d_vs_stock(
+    gpu_available: bool, cellpose_model: Callable[[str], Any]
+) -> None:
     """tile_norm_blocksize>0 (do_3D, norm3D) matches stock eval (AP >= 0.95)."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
-
     from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     vol = _volume_3d()
     normalize = {"tile_norm_blocksize": 32}
-    model = CellposeModel(gpu=True, pretrained_model="cpsam")
+    model = cellpose_model("cpsam")
     m_stock, _, _ = model.eval(
         vol, z_axis=0, diameter=None, do_3D=True, normalize=normalize
     )
@@ -229,19 +261,19 @@ def test_parity_tile_norm_3d_vs_stock(gpu_available: bool) -> None:
     )
 
 
-def test_parity_sharpen_2d_vs_stock(gpu_available: bool) -> None:
+def test_parity_sharpen_2d_vs_stock(
+    gpu_available: bool, cellpose_model: Callable[[str], Any]
+) -> None:
     """sharpen_radius/smooth_radius>0 (2D) matches stock eval (AP >= 0.95)."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
-
     from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     img = _disks()
     normalize = {"sharpen_radius": 8, "smooth_radius": 2}
-    model = CellposeModel(gpu=True, pretrained_model="cpsam")
+    model = cellpose_model("cpsam")
     m_stock, _, _ = model.eval(img, diameter=None, do_3D=False, normalize=normalize)
     m_gpu, _, _ = segment_cellpose(
         model, img, do_3D=False, normalize=normalize, download=True
@@ -255,18 +287,18 @@ def test_parity_sharpen_2d_vs_stock(gpu_available: bool) -> None:
     )
 
 
-def test_list_input_returns_per_image_lists(gpu_available: bool) -> None:
+def test_list_input_returns_per_image_lists(
+    gpu_available: bool, cellpose_model: Callable[[str], Any]
+) -> None:
     """A list of images is processed per-image (mirrors eval) and matches stock."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
-
     from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     imgs = [_disks(), _disks(centers=[(60, 60), (160, 160), (60, 160)], r=18)]
-    model = CellposeModel(gpu=True, pretrained_model="cpsam")
+    model = cellpose_model("cpsam")
     m_stock, _, _ = model.eval(imgs, diameter=None, do_3D=False)
     m_gpu, flows, styles = segment_cellpose(model, imgs, do_3D=False, download=True)
 
@@ -281,18 +313,18 @@ def test_list_input_returns_per_image_lists(gpu_available: bool) -> None:
         assert ap[0] >= 0.95, f"AP@0.5={ap[0]:.3f}"
 
 
-def test_parity_3d_vs_stock(gpu_available: bool) -> None:
+def test_parity_3d_vs_stock(
+    gpu_available: bool, cellpose_model: Callable[[str], Any]
+) -> None:
     """3D (do_3D=True) resident masks match stock eval (AP >= 0.95 @ IoU 0.5)."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
-
     from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     vol = _volume_3d()
-    model = CellposeModel(gpu=True, pretrained_model="cpsam")
+    model = cellpose_model("cpsam")
     m_stock, _, _ = model.eval(vol, z_axis=0, diameter=None, do_3D=True)
     m_gpu, _, _ = segment_cellpose(model, vol, z_axis=0, do_3D=True, download=True)
 
@@ -305,18 +337,18 @@ def test_parity_3d_vs_stock(gpu_available: bool) -> None:
     )
 
 
-def test_parity_stitch_vs_stock(gpu_available: bool) -> None:
+def test_parity_stitch_vs_stock(
+    gpu_available: bool, cellpose_model: Callable[[str], Any]
+) -> None:
     """Stitched 3D masks (stitch_threshold>0) match stock eval (AP >= 0.95)."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
-
     from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     stack = _zstack()
-    model = CellposeModel(gpu=True, pretrained_model="cpsam")
+    model = cellpose_model("cpsam")
     m_stock, _, _ = model.eval(
         stack, z_axis=0, diameter=None, do_3D=False, stitch_threshold=0.5
     )
@@ -350,18 +382,18 @@ def test_fill_holes_fills_interior(gpu_available: bool) -> None:
     assert int(out[20, 20]) == 1  # interior hole filled (slice write-back works)
 
 
-def test_residency_single_download(gpu_available: bool) -> None:
+def test_residency_single_download(
+    gpu_available: bool, cellpose_model: Callable[[str], Any]
+) -> None:
     """download=False: only the final mask leaves the GPU; flows stay CuPy."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
-
     from cubic.cuda import get_device
     from cubic.segmentation import cellpose_sam_gpu as g
 
     img = _disks()
-    model = CellposeModel(gpu=True, pretrained_model="cpsam")
+    model = cellpose_model("cpsam")
 
     calls = {"n": 0}
     orig = g.asnumpy
@@ -388,19 +420,17 @@ def test_residency_single_download(gpu_available: bool) -> None:
 # backbone-appropriate default tile size (256 for SAM, 384 for DINO).
 @pytest.mark.parametrize("pretrained_model", ["cpsam_v2", "cpdino", "cpdino-vitb"])
 def test_parity_2d_vs_stock_new_models(
-    gpu_available: bool, pretrained_model: str
+    gpu_available: bool, cellpose_model: Callable[[str], Any], pretrained_model: str
 ) -> None:
     """Each new v4 model's resident masks match stock eval (AP >= 0.95)."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
-
     from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     img = _disks()
-    model = CellposeModel(gpu=True, pretrained_model=pretrained_model)
+    model = cellpose_model(pretrained_model)
     m_stock, _, _ = model.eval(img, diameter=None, do_3D=False)
     m_gpu, _, _ = segment_cellpose(model, img, do_3D=False, download=True)
 
@@ -413,18 +443,18 @@ def test_parity_2d_vs_stock_new_models(
     )
 
 
-def test_parity_3d_vs_stock_dino(gpu_available: bool) -> None:
+def test_parity_3d_vs_stock_dino(
+    gpu_available: bool, cellpose_model: Callable[[str], Any]
+) -> None:
     """A DINO backbone (cpdino) matches stock eval in 3D (AP >= 0.95)."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
-
     from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     vol = _volume_3d()
-    model = CellposeModel(gpu=True, pretrained_model="cpdino")
+    model = cellpose_model("cpdino")
     assert model.backbone == "dino_vitl"
     m_stock, _, _ = model.eval(vol, z_axis=0, diameter=None, do_3D=True)
     m_gpu, _, _ = segment_cellpose(model, vol, z_axis=0, do_3D=True, download=True)
@@ -451,18 +481,18 @@ def test_resolve_bsize_defaults_and_guard() -> None:
         g._resolve_bsize("sam_vitl", 128)  # SAM is pinned to 256
 
 
-def test_dino_bsize_override_parity(gpu_available: bool) -> None:
+def test_dino_bsize_override_parity(
+    gpu_available: bool, cellpose_model: Callable[[str], Any]
+) -> None:
     """A custom bsize threads through for DINO and matches stock eval at bsize."""
     if not gpu_available:
         pytest.skip("requires a CUDA GPU")
     _require_cellpose_v4()
-    from cellpose.models import CellposeModel
-
     from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     img = _disks()
-    model = CellposeModel(gpu=True, pretrained_model="cpdino-vitb")
+    model = cellpose_model("cpdino-vitb")
     assert model.backbone == "dino_vitb"
     m_stock, _, _ = model.eval(img, diameter=None, do_3D=False, bsize=256)
     m_gpu, _, _ = segment_cellpose(model, img, do_3D=False, bsize=256, download=True)

--- a/tests/segmentation/test_cellpose_sam_gpu.py
+++ b/tests/segmentation/test_cellpose_sam_gpu.py
@@ -479,6 +479,10 @@ def test_resolve_bsize_defaults_and_guard() -> None:
     assert g._resolve_bsize("dino_vitl", 256) == 256  # DINO accepts other sizes
     with pytest.raises(ValueError, match="bsize"):
         g._resolve_bsize("sam_vitl", 128)  # SAM is pinned to 256
+    with pytest.raises(ValueError, match="positive"):
+        g._resolve_bsize("dino_vitl", 0)  # non-positive tile size rejected
+    with pytest.raises(ValueError, match="positive"):
+        g._resolve_bsize("dino_vitb", -16)
 
 
 def test_dino_bsize_override_parity(

--- a/tests/segmentation/test_cellpose_sam_gpu.py
+++ b/tests/segmentation/test_cellpose_sam_gpu.py
@@ -4,6 +4,8 @@ Module-level imports stay free of optional deps (cellpose/cupy/torch) so the
 suite collects on CPU/no-GPU CI; GPU/cellpose-dependent tests skip cleanly.
 """
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -56,7 +58,30 @@ def test_segmentation_imports_without_optional_deps() -> None:
     import importlib
 
     mod = importlib.import_module("cubic.segmentation")
-    assert hasattr(mod, "segment_cpsam")
+    assert hasattr(mod, "segment_cellpose")
+    assert hasattr(mod, "segment_cpsam")  # deprecated alias still exported
+
+
+def test_deprecated_segment_cpsam_alias_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``segment_cpsam`` warns and forwards verbatim to ``segment_cellpose``."""
+    from cubic.segmentation import cellpose_sam_gpu as g
+
+    captured: dict[str, Any] = {}
+
+    def _stub(model: Any, x: Any, **kwargs: Any) -> tuple[Any, list, Any]:
+        captured["model"], captured["x"], captured["kwargs"] = model, x, kwargs
+        return "masks", [None], "styles"
+
+    monkeypatch.setattr(g, "segment_cellpose", _stub)
+    sentinel = object()
+    with pytest.warns(DeprecationWarning, match="segment_cellpose"):
+        out = g.segment_cpsam(sentinel, 123, bsize=384, do_3D=True)
+
+    assert out == ("masks", [None], "styles")
+    assert captured["model"] is sentinel and captured["x"] == 123
+    assert captured["kwargs"] == {"bsize": 384, "do_3D": True}
 
 
 def test_resident_requires_cellpose(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -65,7 +90,7 @@ def test_resident_requires_cellpose(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(g, "_CELLPOSE_AVAILABLE", False)
     with pytest.raises(ImportError):
-        g.segment_cpsam(object(), np.zeros((32, 32), np.float32))
+        g.segment_cellpose(object(), np.zeros((32, 32), np.float32))
 
 
 def test_resident_rejects_non_cuda_model() -> None:
@@ -84,7 +109,7 @@ def test_resident_rejects_non_cuda_model() -> None:
         device = torch.device("cpu")
 
     with pytest.raises(RuntimeError):
-        g.segment_cpsam(_Model(), np.zeros((32, 32), np.float32))
+        g.segment_cellpose(_Model(), np.zeros((32, 32), np.float32))
 
 
 def test_sam_model_exposes_v4_api(gpu_available: bool) -> None:
@@ -133,13 +158,13 @@ def test_parity_2d_vs_stock(gpu_available: bool) -> None:
     _require_cellpose_v4()
     from cellpose.models import CellposeModel
 
-    from cubic.segmentation import segment_cpsam
+    from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     img = _disks()
     model = CellposeModel(gpu=True, pretrained_model="cpsam")
     m_stock, _, _ = model.eval(img, diameter=None, do_3D=False)
-    m_gpu, _, _ = segment_cpsam(model, img, do_3D=False, download=True)
+    m_gpu, _, _ = segment_cellpose(model, img, do_3D=False, download=True)
 
     m_stock = m_stock.astype(np.int32)
     m_gpu = np.asarray(m_gpu).astype(np.int32)
@@ -156,14 +181,14 @@ def test_parity_tile_norm_2d_vs_stock(gpu_available: bool) -> None:
     _require_cellpose_v4()
     from cellpose.models import CellposeModel
 
-    from cubic.segmentation import segment_cpsam
+    from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     img = _disks()
     normalize = {"tile_norm_blocksize": 64}
     model = CellposeModel(gpu=True, pretrained_model="cpsam")
     m_stock, _, _ = model.eval(img, diameter=None, do_3D=False, normalize=normalize)
-    m_gpu, _, _ = segment_cpsam(
+    m_gpu, _, _ = segment_cellpose(
         model, img, do_3D=False, normalize=normalize, download=True
     )
 
@@ -182,7 +207,7 @@ def test_parity_tile_norm_3d_vs_stock(gpu_available: bool) -> None:
     _require_cellpose_v4()
     from cellpose.models import CellposeModel
 
-    from cubic.segmentation import segment_cpsam
+    from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     vol = _volume_3d()
@@ -191,7 +216,7 @@ def test_parity_tile_norm_3d_vs_stock(gpu_available: bool) -> None:
     m_stock, _, _ = model.eval(
         vol, z_axis=0, diameter=None, do_3D=True, normalize=normalize
     )
-    m_gpu, _, _ = segment_cpsam(
+    m_gpu, _, _ = segment_cellpose(
         model, vol, z_axis=0, do_3D=True, normalize=normalize, download=True
     )
 
@@ -211,14 +236,14 @@ def test_parity_sharpen_2d_vs_stock(gpu_available: bool) -> None:
     _require_cellpose_v4()
     from cellpose.models import CellposeModel
 
-    from cubic.segmentation import segment_cpsam
+    from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     img = _disks()
     normalize = {"sharpen_radius": 8, "smooth_radius": 2}
     model = CellposeModel(gpu=True, pretrained_model="cpsam")
     m_stock, _, _ = model.eval(img, diameter=None, do_3D=False, normalize=normalize)
-    m_gpu, _, _ = segment_cpsam(
+    m_gpu, _, _ = segment_cellpose(
         model, img, do_3D=False, normalize=normalize, download=True
     )
 
@@ -237,13 +262,13 @@ def test_list_input_returns_per_image_lists(gpu_available: bool) -> None:
     _require_cellpose_v4()
     from cellpose.models import CellposeModel
 
-    from cubic.segmentation import segment_cpsam
+    from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     imgs = [_disks(), _disks(centers=[(60, 60), (160, 160), (60, 160)], r=18)]
     model = CellposeModel(gpu=True, pretrained_model="cpsam")
     m_stock, _, _ = model.eval(imgs, diameter=None, do_3D=False)
-    m_gpu, flows, styles = segment_cpsam(model, imgs, do_3D=False, download=True)
+    m_gpu, flows, styles = segment_cellpose(model, imgs, do_3D=False, download=True)
 
     assert (
         isinstance(m_gpu, list) and isinstance(flows, list) and isinstance(styles, list)
@@ -263,13 +288,13 @@ def test_parity_3d_vs_stock(gpu_available: bool) -> None:
     _require_cellpose_v4()
     from cellpose.models import CellposeModel
 
-    from cubic.segmentation import segment_cpsam
+    from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     vol = _volume_3d()
     model = CellposeModel(gpu=True, pretrained_model="cpsam")
     m_stock, _, _ = model.eval(vol, z_axis=0, diameter=None, do_3D=True)
-    m_gpu, _, _ = segment_cpsam(model, vol, z_axis=0, do_3D=True, download=True)
+    m_gpu, _, _ = segment_cellpose(model, vol, z_axis=0, do_3D=True, download=True)
 
     m_stock = np.asarray(m_stock).astype(np.int32)
     m_gpu = np.asarray(m_gpu).astype(np.int32)
@@ -287,7 +312,7 @@ def test_parity_stitch_vs_stock(gpu_available: bool) -> None:
     _require_cellpose_v4()
     from cellpose.models import CellposeModel
 
-    from cubic.segmentation import segment_cpsam
+    from cubic.segmentation import segment_cellpose
     from cubic.metrics.average_precision import average_precision
 
     stack = _zstack()
@@ -295,7 +320,7 @@ def test_parity_stitch_vs_stock(gpu_available: bool) -> None:
     m_stock, _, _ = model.eval(
         stack, z_axis=0, diameter=None, do_3D=False, stitch_threshold=0.5
     )
-    m_gpu, _, _ = segment_cpsam(
+    m_gpu, _, _ = segment_cellpose(
         model, stack, z_axis=0, do_3D=False, stitch_threshold=0.5, download=True
     )
 
@@ -347,7 +372,7 @@ def test_residency_single_download(gpu_available: bool) -> None:
 
     g.asnumpy = _spy
     try:
-        masks, flows, _ = g.segment_cpsam(model, img, do_3D=False, download=False)
+        masks, flows, _ = g.segment_cellpose(model, img, do_3D=False, download=False)
     finally:
         g.asnumpy = orig
 
@@ -356,3 +381,97 @@ def test_residency_single_download(gpu_available: bool) -> None:
     assert get_device(flows[1]) == "GPU"  # dP stays resident
     assert get_device(flows[2]) == "GPU"  # cellprob stays resident
     assert calls["n"] == 1  # exactly one device->host array transfer
+
+
+# new Cellpose v4 backbones: cpsam_v2 (SAM-ViTL), cpdino (DINOv3-ViTL),
+# cpdino-vitb (DINOv3-ViTB). Each routes through segment_cellpose with the
+# backbone-appropriate default tile size (256 for SAM, 384 for DINO).
+@pytest.mark.parametrize("pretrained_model", ["cpsam_v2", "cpdino", "cpdino-vitb"])
+def test_parity_2d_vs_stock_new_models(
+    gpu_available: bool, pretrained_model: str
+) -> None:
+    """Each new v4 model's resident masks match stock eval (AP >= 0.95)."""
+    if not gpu_available:
+        pytest.skip("requires a CUDA GPU")
+    _require_cellpose_v4()
+    from cellpose.models import CellposeModel
+
+    from cubic.segmentation import segment_cellpose
+    from cubic.metrics.average_precision import average_precision
+
+    img = _disks()
+    model = CellposeModel(gpu=True, pretrained_model=pretrained_model)
+    m_stock, _, _ = model.eval(img, diameter=None, do_3D=False)
+    m_gpu, _, _ = segment_cellpose(model, img, do_3D=False, download=True)
+
+    m_stock = np.asarray(m_stock).astype(np.int32)
+    m_gpu = np.asarray(m_gpu).astype(np.int32)
+    ap, _, _, _ = average_precision(m_stock, m_gpu, [0.5])
+    assert ap[0] >= 0.95, (
+        f"{pretrained_model} AP@0.5={ap[0]:.3f} "
+        f"(stock n={m_stock.max()}, gpu n={m_gpu.max()})"
+    )
+
+
+def test_parity_3d_vs_stock_dino(gpu_available: bool) -> None:
+    """A DINO backbone (cpdino) matches stock eval in 3D (AP >= 0.95)."""
+    if not gpu_available:
+        pytest.skip("requires a CUDA GPU")
+    _require_cellpose_v4()
+    from cellpose.models import CellposeModel
+
+    from cubic.segmentation import segment_cellpose
+    from cubic.metrics.average_precision import average_precision
+
+    vol = _volume_3d()
+    model = CellposeModel(gpu=True, pretrained_model="cpdino")
+    assert model.backbone == "dino_vitl"
+    m_stock, _, _ = model.eval(vol, z_axis=0, diameter=None, do_3D=True)
+    m_gpu, _, _ = segment_cellpose(model, vol, z_axis=0, do_3D=True, download=True)
+
+    m_stock = np.asarray(m_stock).astype(np.int32)
+    m_gpu = np.asarray(m_gpu).astype(np.int32)
+    assert m_stock.shape == m_gpu.shape == vol.shape
+    ap, _, _, _ = average_precision(m_stock, m_gpu, [0.5])
+    assert ap[0] >= 0.95, (
+        f"AP@0.5={ap[0]:.3f} (stock n={m_stock.max()}, gpu n={m_gpu.max()})"
+    )
+
+
+def test_bsize_guard_rejects_non256_for_sam(gpu_available: bool) -> None:
+    """The SAM backbone rejects bsize != 256 (mirrors CellposeModel.eval)."""
+    if not gpu_available:
+        pytest.skip("requires a CUDA GPU")
+    _require_cellpose_v4()
+    from cellpose.models import CellposeModel
+
+    from cubic.segmentation import segment_cellpose
+
+    model = CellposeModel(gpu=True, pretrained_model="cpsam")
+    assert model.backbone == "sam_vitl"
+    with pytest.raises(ValueError, match="bsize"):
+        segment_cellpose(model, _disks(), do_3D=False, bsize=128)
+
+
+def test_dino_bsize_override_parity(gpu_available: bool) -> None:
+    """A custom bsize threads through for DINO and matches stock eval at bsize."""
+    if not gpu_available:
+        pytest.skip("requires a CUDA GPU")
+    _require_cellpose_v4()
+    from cellpose.models import CellposeModel
+
+    from cubic.segmentation import segment_cellpose
+    from cubic.metrics.average_precision import average_precision
+
+    img = _disks()
+    model = CellposeModel(gpu=True, pretrained_model="cpdino-vitb")
+    assert model.backbone == "dino_vitb"
+    m_stock, _, _ = model.eval(img, diameter=None, do_3D=False, bsize=256)
+    m_gpu, _, _ = segment_cellpose(model, img, do_3D=False, bsize=256, download=True)
+
+    m_stock = np.asarray(m_stock).astype(np.int32)
+    m_gpu = np.asarray(m_gpu).astype(np.int32)
+    ap, _, _, _ = average_precision(m_stock, m_gpu, [0.5])
+    assert ap[0] >= 0.95, (
+        f"AP@0.5={ap[0]:.3f} (stock n={m_stock.max()}, gpu n={m_gpu.max()})"
+    )

--- a/tests/segmentation/test_cellpose_sam_gpu.py
+++ b/tests/segmentation/test_cellpose_sam_gpu.py
@@ -438,19 +438,17 @@ def test_parity_3d_vs_stock_dino(gpu_available: bool) -> None:
     )
 
 
-def test_bsize_guard_rejects_non256_for_sam(gpu_available: bool) -> None:
-    """The SAM backbone rejects bsize != 256 (mirrors CellposeModel.eval)."""
-    if not gpu_available:
-        pytest.skip("requires a CUDA GPU")
-    _require_cellpose_v4()
-    from cellpose.models import CellposeModel
+def test_resolve_bsize_defaults_and_guard() -> None:
+    """_resolve_bsize is the single backbone->tile-size rule (no GPU/cellpose)."""
+    from cubic.segmentation import cellpose_sam_gpu as g
 
-    from cubic.segmentation import segment_cellpose
-
-    model = CellposeModel(gpu=True, pretrained_model="cpsam")
-    assert model.backbone == "sam_vitl"
+    assert g._resolve_bsize("sam_vitl", None) == 256  # SAM default
+    assert g._resolve_bsize("sam_vitl", 256) == 256
+    assert g._resolve_bsize("dino_vitl", None) == 384  # DINO default
+    assert g._resolve_bsize("dino_vitb", None) == 384
+    assert g._resolve_bsize("dino_vitl", 256) == 256  # DINO accepts other sizes
     with pytest.raises(ValueError, match="bsize"):
-        segment_cellpose(model, _disks(), do_3D=False, bsize=128)
+        g._resolve_bsize("sam_vitl", 128)  # SAM is pinned to 256
 
 
 def test_dino_bsize_override_parity(gpu_available: bool) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,7 @@ css = [
 
 [[package]]
 name = "cellpose"
-version = "4.1.1"
+version = "4.2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastremap" },
@@ -184,9 +184,9 @@ dependencies = [
     { name = "torchvision" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/b0/3dde4f82033a4b8e35a48d7419aa9c4f3e7c1100055a135790a41c47f19b/cellpose-4.1.1.tar.gz", hash = "sha256:859c732c8edede78ec7ee6537c5cfb18ab54f3dc01846adc10edca0cec124094", size = 4252891, upload-time = "2026-03-31T16:40:23.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/e4/3d4606883a5489b86fa6ab5f65b9d0a243810f64efb934033fe425089d5a/cellpose-4.2.1.1.tar.gz", hash = "sha256:229eedea3977184202b2c87b3bd41c609facd742c7203bb4ad3cebd7b6bc6839", size = 4441350, upload-time = "2026-06-14T14:25:15.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/33/c2fbe5d074e2bb95bacdada02ebfa05915d211b67ab590419be1449d2115/cellpose-4.1.1-py3-none-any.whl", hash = "sha256:52d33d3c890df5572bec029ec4211388611b313c58f7b7073f47622b9befc32a", size = 213394, upload-time = "2026-03-31T16:40:21.147Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/20/d9d1fa1abffc8dab4381116ea0d91e8f8e4315acc038b76679608c097649/cellpose-4.2.1.1-py3-none-any.whl", hash = "sha256:6c5c5159fd459115bee390ffb01d94d5e1006b97c211bf3c1a7b37d5395a1a13", size = 203334, upload-time = "2026-06-14T14:25:13.797Z" },
 ]
 
 [[package]]
@@ -599,7 +599,7 @@ plot = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cellpose", marker = "extra == 'cellpose'", specifier = ">=4.0" },
+    { name = "cellpose", marker = "extra == 'cellpose'", specifier = ">=4.2.0" },
     { name = "cubic", extras = ["cellpose"], marker = "extra == 'all'" },
     { name = "cubic", extras = ["dev"], marker = "extra == 'all'" },
     { name = "cubic", extras = ["examples"], marker = "extra == 'all'" },
@@ -1025,13 +1025,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/81/af/f03fa2a60617a46814fea5523f8d53a703aabbb316e029b21efe8fe04f9f/imagecodecs-2026.1.14-cp311-abi3-win32.whl", hash = "sha256:6bbf7defac9f71e0401305440f7e94160201789e03ee75e6e5709bc904742429", size = 17224233, upload-time = "2026-01-14T04:23:58.261Z" },
     { url = "https://files.pythonhosted.org/packages/b6/22/ae01473653dbad9e10a1632b5d8ae6473de0f3ec2b82c912836661d501a9/imagecodecs-2026.1.14-cp311-abi3-win_amd64.whl", hash = "sha256:13ec4659d05010aa072644f100d0e1e1fcc61d7eaa960923b8216272682e6c9a", size = 21544843, upload-time = "2026-01-14T04:24:02.387Z" },
     { url = "https://files.pythonhosted.org/packages/54/6e/86fa1a07aee2ea39acfa04e372a144a72b4cdc80f40a11a3ee312c12d312/imagecodecs-2026.1.14-cp311-abi3-win_arm64.whl", hash = "sha256:2a6102f3b99c66e090a619f8a0204e6e95c01399854ffa09e4a9de476dc1671a", size = 16893409, upload-time = "2026-01-14T04:24:05.764Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/a3/f92989c2de762ee4db9f5454bbafa540cfa13d28006b4aeb01936f9a4a8a/imagecodecs-2026.1.14-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:455915b32ae1ecccaeb9dad32ad1499aa2e6928b6b853e3635cb32af9aa56857", size = 13202548, upload-time = "2026-01-14T04:24:08.515Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/da/9fb0e446f5af6fa21f44a1f1d4950e538345d7e8931b5983a543a24b9c38/imagecodecs-2026.1.14-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c189f5d842f1f2524c27c307220c5f2cf201af44dab74b1f7476645f72eb2e87", size = 11004937, upload-time = "2026-01-14T04:24:11.054Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/e9/0400722f5bdaaa9bc13ad77c78606cfb767f2b609cb136cc81d81c380807/imagecodecs-2026.1.14-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca3325e68dffeb29383f4a28957ac61d3c0ade1b244ebf70797bdaf009ad1578", size = 27442756, upload-time = "2026-01-14T04:24:15.247Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f1/f39cacf55d5e7175f1e7b5222178e7c56d6ca1a49e61011adb1150d85aec/imagecodecs-2026.1.14-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6819b8365cf28e2a85dcb04fb9c1f1acb63cf5da61495910cd751a7e2548e1d", size = 28006255, upload-time = "2026-01-14T04:24:19.458Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/58/b098490e93435ef4311c473e30588e80f966f6d676f1343804f8ab3fcff1/imagecodecs-2026.1.14-cp314-cp314t-win32.whl", hash = "sha256:ae422def59fab163ba0cb79470e10aa64b8a62b29e74d50ecd0edab4349444c2", size = 17909361, upload-time = "2026-01-14T04:24:22.548Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/35/cb1fc0ce35dd61475672af65607fe2c3cc30d7844d617067a3e649b8366e/imagecodecs-2026.1.14-cp314-cp314t-win_amd64.whl", hash = "sha256:9b11ced125e7b8da2a9d1a30505827cdb27f7023ccee4cd4cc5e3b352dce8574", size = 22496362, upload-time = "2026-01-14T04:24:25.874Z" },
-    { url = "https://files.pythonhosted.org/packages/04/f7/2dfe80928bf0c6c6e7411954fa008a71d0b08e72fe1028fe9a8a8116588a/imagecodecs-2026.1.14-cp314-cp314t-win_arm64.whl", hash = "sha256:d4c19df6142481d2fda62d91542c078aecd647f120da52cc79019ed6938e587d", size = 17534288, upload-time = "2026-01-14T04:24:28.911Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Extends cubic's device-resident Cellpose segmentation to support **all four Cellpose v4 models**, not just the original SAM weights:

| Model | Backbone | Default tile |
|---|---|---|
| `cpsam` | sam_vitl | 256 |
| `cpsam_v2` | sam_vitl | 256 |
| `cpdino` | dino_vitl | 384 |
| `cpdino-vitb` | dino_vitb | 384 |

Both `CPSAM` and `CPDINO` forwards return the identical `(flow[B,3,bsize,bsize], style[B,256])` contract; the only backbone-specific behavior is the tile size, which cubic already mirrored. So the resident path needed only to expose `bsize` and centralize the backbone→tile-size rule.

## Changes

- **`segment_cellpose`** is now the canonical GPU-resident entry point (covers SAM + DINO). `segment_cpsam` is kept as a **deprecated alias** (emits `DeprecationWarning`, slated for removal after 0.8). Both are exported.
- Added a **`bsize`** parameter, threaded through the network forward, with cellpose's `sam_vitl → 256` guard. DINO tile size is tunable.
- Centralized the backbone→tile-size rule into a single `_resolve_bsize(backbone, bsize)` helper (default + validation), removing the now-unused `backbone` arg from `_run_net_gpu`.
- Generalized the non-resident `cellpose_eval`/`cellpose_segment` docstrings (they already accept any model name).
- Packaging: base `cellpose` pin bumped to **`>=4.2.0`** (the release that ships cpsam_v2/cpdino) and a new **`cellpose-dino`** extra (`cubic[cellpose]` + `cellpose[dino]>=4.2.0`) for the `dinov3` dependency. README install note added.
- Bumped version to `0.8.0a1`.

## Tests

- Parametrized 2D parity over `cpsam_v2`, `cpdino`, `cpdino-vitb`; a DINO 3D parity test; a DINO `bsize`-override parity test (all GPU-gated, vs stock `CellposeModel.eval`, AP@0.5 ≥ 0.95).
- A fast pure-function unit test for `_resolve_bsize` (no GPU).
- A deprecation-alias test verifying `segment_cpsam` warns and forwards verbatim.
- A module-scoped fixture that caches one `CellposeModel` per backbone, so the GPU suite reloads each weight set only once.

## Verification

- `ruff check`, `ruff format --check`, `mypy` clean.
- Full cellpose-resident GPU suite: **21 passed** (AP ≥ 0.95 parity for all four models, 2D + 3D, on real GPU weights).
- Full project suite: **364 passed** (pre-existing unrelated warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend GPU-resident Cellpose segmentation to support all Cellpose v4 models and rename the main entry point, while preserving compatibility via a deprecated alias.

New Features:
- Add a unified segment_cellpose GPU-resident entry point that supports SAM and DINO Cellpose v4 backbones, with configurable tile size.
- Introduce a backbone-aware tile-size resolver to mirror Cellpose v4 defaults and validation across SAM and DINO models.

Enhancements:
- Generalize existing Cellpose helpers and docstrings from SAM-only to any Cellpose v4 model.
- Cache CellposeModel instances per backbone in tests to avoid reloading weights for each test run.
- Update project version to 0.8.0a1.

Build:
- Bump the Cellpose dependency to >=4.2.0 and introduce a cellpose-dino extra, wiring it into the all extra.

Documentation:
- Document the new Cellpose DINO extra and clarify installation instructions and supported models in the README.

Tests:
- Expand GPU parity tests to cover new Cellpose v4 backbones, 3D DINO usage, custom tile sizes, and the deprecated alias behavior while adding a unit test for tile-size resolution.